### PR TITLE
Add Detox plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ npm start
 - @nativescript/brightness
 - @nativescript/camera
 - @nativescript/datetimepicker
+- @nativescript/detox
 - @nativescript/directions
 - @nativescript/email
 - @nativescript/fingerprint-auth

--- a/nx.json
+++ b/nx.json
@@ -76,6 +76,9 @@
 		},
 		"localize": {
 			"tags": []
+		},
+		"detox": {
+			"tags": []
 		}
 	},
 	"workspaceLayout": {

--- a/packages/detox/README.md
+++ b/packages/detox/README.md
@@ -1,0 +1,238 @@
+# NativeScript Detox
+
+Easily add [Detox](https://github.com/wix/Detox) end-to-end testing to your NativeScript apps! 
+
+| <img src="https://i.imgur.com/apdbINz.gif" /> | <img src="https://i.imgur.com/mWBBF26.gif" /> |
+| --- | ----------- |
+| iOS Demo | Android Demo |
+
+---
+
+## Table of Contents
+1. [Installation](#installation)
+2. [Global Setup](#global-setup)
+3. [Project Setup](#project-setup)
+4. [Usage](#usage)
+5. [Running Tests](#running-tests)
+6. [Troubleshooting](#troubleshooting)
+
+## Installation
+
+```
+ns plugin add @nativescript/detox
+```
+
+## Global Setup
+
+The full setup requirements can be found [here](https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md) but the minimal setup steps are as follows:
+
+### Install Detox command line tools (`detox-cli`)
+
+```
+npm install -g detox-cli
+```
+
+### Install [applesimutils](https://github.com/wix/AppleSimulatorUtils) (iOS)
+
+```
+brew tap wix/brew
+brew install applesimutils
+```
+
+## Project Setup
+
+### Install the Detox package to your NativeScript project
+
+```
+npm install detox --save-dev
+```
+
+### Install Jest
+
+```
+npm install jest jest-cli jest-circus --save-dev --no-package-lock
+```
+
+### Initialize Detox
+
+```
+detox init -r jest
+```
+
+If things go well, you should to have this set up:
+
+* An `e2e/` folder in your project root
+* An `e2e/config.json` file; [example](https://github.com/wix/Detox/blob/master/examples/demo-react-native-jest/e2e/config.json)
+* An `e2e/environment.js` file; [example](https://github.com/wix/Detox/blob/master/examples/demo-react-native-jest/e2e/environment.js)
+* An `e2e/firstTest.e2e.js` file with content similar to [this](https://github.com/wix/Detox/blob/master/examples/demo-react-native-jest/e2e/app-hello.e2e.js).
+
+There should also be a file called `.detoxrc.json` in your project root.
+
+### Configure Detox
+
+Detox must be configued to know the location of the iOS and Android app binary as well as what emulator/simulator to use.
+
+Open `.detoxrc.json` and make the following modifications under `configurations` for iOS and Android.
+
+* `binaryPath`: Specify the location of the app binary (probably something like below).
+  * iOS: `platforms/ios/build/Debug-iphonesimulator/[APP_NAME].app`
+  * Android: `platforms/android/app/build/outputs/apk/debug/app-debug.apk`
+
+* `build`: Specify the build command for iOS and Android.
+  * iOS: `ns build ios`
+  * Android: `ns build android --detox`
+
+* `device`:
+  * iOS: `"type": "iPhone 11"` 
+  * Android: `"avdName": "Pixel_3a_API_30_1"` (use `emulator -list-avds` to list Android emulators)
+
+Here is a full example of a Detox configuration:
+
+```json
+{
+  "testRunner": "jest",
+  "runnerConfig": "e2e/config.json",
+  "configurations": {
+    "ios": {
+      "binaryPath": "platforms/ios/build/Debug-iphonesimulator/[APP_NAME].app",
+      "build": "ns build ios",
+      "type": "ios.simulator",
+      "device": {
+        "type": "iPhone 11"
+      }
+    },
+    "android": {
+      "binaryPath": "platforms/android/app/build/outputs/apk/debug/app-debug.apk",
+      "build": "ns build android --detox",
+      "type": "android.emulator",
+      "device": {
+        "avdName": "Pixel_3a_API_30_1"
+      }
+    }
+  }
+}
+```
+
+**NOTE:** A default NativeScript Android project uses 17 as the minimum SDK, but Detox requires >=18. Remove or modify the `minSdkVersion` in your `App_Resources/Android/app.gradle`.
+
+## Usage
+
+Read through [this tutorial](https://github.com/wix/Detox/blob/master/docs/Introduction.WritingFirstTest.md) written by Detox about writing your first test. Nearly all of the things specified towards React Native apps also apply to NativeScript apps.
+
+Get started by opening the default test scenario in `e2e/firstTest.e2e.js`.
+
+```javascript
+describe('Example', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('should have welcome screen', async () => {
+    await expect(element(by.text('Sergio'))).toBeVisible();
+  });
+});
+```
+
+This example creates a testing scenario called `Example` and has a single test inside of it called `should have welcome screen`.
+
+### Matchers
+
+Detox uses [matchers](https://github.com/wix/Detox/blob/master/docs/APIRef.Matchers.md) to find elements in your UI to interact with such as `by.id()` or `by.text()`.
+
+You can use the `testID` property to find your UI elements by a unique identifier in NativeScript (like in React Native).
+
+Example `by.id()`:
+
+```xml
+<Button text="Tap Me!" testID="testButton"></Button>
+```
+
+```javascript
+await element(by.id('testButton')).tap();
+```
+
+You can also use the `automationText` property to find your UI elements.
+
+Example `by.label()`:
+
+```xml
+<Button text="Tap Me!" automationText="testButton"></Button>
+```
+
+```javascript
+await element(by.label('testButton')).tap();
+```
+
+### Actions
+
+Once you find your UI element you can use an [action](https://github.com/wix/Detox/blob/master/docs/APIRef.ActionsOnElement.md) on it such as `tap()` to simulate user interaction.
+
+You should now be able to write tests to simulate user behavior and test for expected results.
+
+## Running Tests
+
+### Building
+
+Build your app for testing using the following command:
+
+```
+detox build -c ios|android
+```
+
+### Testing
+
+Run your tests with the folling command:
+
+```
+detox test -c ios|android
+```
+
+**NOTE:** If using an Android emulator, Detox will disable animations when the tests are ran. Animations will remain disabled after they are finished. This can be very annoying when you are actively developing. You can re-enable animations by running this helper script from your project's directory `./node_modules/.bin/enable-animations`.
+
+To make this even easier I would suggest adding these scripts to your `package.json`.
+
+```json
+{
+  "scripts": {
+    ...
+    "e2e:android:build": "detox build -c android",
+    "e2e:android:test": "detox test -c android && ./node_modules/.bin/enable-animations",
+    "e2e:ios:build": "detox build -c ios",
+    "e2e:ios:test": "detox test -c ios",
+    ...
+  }
+}
+```
+
+Now to build and run tests you would run:
+
+Android:
+```
+npm run e2e:android:build
+npm run e2e:android:test
+```
+
+iOS:
+
+```
+npm run e2e:ios:build
+npm run e2e:ios:test
+```
+
+## Troubleshooting
+
+Detox requires a minimum SDK version of 18, so if you get the following error, change the `minSdkVersion` to 18 in `App_Resources/Android/app.gradle`.
+
+```
+Execution failed for task ':app:processDebugAndroidTestManifest'.
+Manifest merger failed : uses-sdk:minSdkVersion 17 cannot be smaller than version 18 declared in library [com.wix:detox:17.6.1] /Users/user/.gradle/caches/transforms-2/files-2.1/91a3acd87d710d1913b266ac114d7001/jetified-detox-17.6.1/AndroidManifest.xml as the library might be using APIs not available in 17
+        Suggestion: use a compatible library with a minSdk of at most 17,
+                or increase this project's minSdk version to at least 18,
+                or use tools:overrideLibrary="com.wix.detox" to force usage (may lead to runtime failures)
+
+Command ./gradlew failed with exit code 1
+```
+
+## License
+
+Apache License Version 2.0

--- a/packages/detox/README.md
+++ b/packages/detox/README.md
@@ -137,21 +137,9 @@ This example creates a testing scenario called `Example` and has a single test i
 
 ### Matchers
 
-Detox uses [matchers](https://github.com/wix/Detox/blob/master/docs/APIRef.Matchers.md) to find elements in your UI to interact with such as `by.id()` or `by.text()`.
+Detox uses [matchers](https://github.com/wix/Detox/blob/master/docs/APIRef.Matchers.md) to find elements in your UI to interact with such as `by.label()` or `by.text()`.
 
-You can use the `testID` property to find your UI elements by a unique identifier in NativeScript (like in React Native).
-
-Example `by.id()`:
-
-```xml
-<Button text="Tap Me!" testID="testButton"></Button>
-```
-
-```javascript
-await element(by.id('testButton')).tap();
-```
-
-You can also use the `automationText` property to find your UI elements.
+You can use the `automationText` property to find your UI elements by a unique label in NativeScript.
 
 Example `by.label()`:
 

--- a/packages/detox/package.json
+++ b/packages/detox/package.json
@@ -1,0 +1,52 @@
+{
+	"name": "@nativescript/detox",
+	"version": "1.0.0",
+	"description": "Add a plugin description",
+	"main": "index",
+	"typings": "index.d.ts",
+	"bin": {
+		"enable-animations": "scripts/enable-animations.js"
+	},
+	"scripts": {
+		"postinstall": "node postinstall.js",
+		"preuninstall": "node preuninstall.js"
+	},
+	"nativescript": {
+		"platforms": {
+			"ios": "6.0.0",
+			"android": "6.0.0"
+		},
+		"hooks": [
+			{
+				"type": "before-build-task-args",
+				"script": "scripts/detox-build.js",
+				"inject": true
+			}
+		]
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/NativeScript/plugins.git"
+	},
+	"keywords": [
+		"NativeScript",
+		"JavaScript",
+		"TypeScript",
+		"iOS",
+		"Android"
+	],
+	"author": {
+		"name": "NativeScript",
+		"email": "oss@nativescript.org"
+	},
+	"bugs": {
+		"url": "https://github.com/NativeScript/plugins/issues"
+	},
+	"license": "Apache-2.0",
+	"homepage": "https://github.com/NativeScript/plugins",
+	"readmeFilename": "README.md",
+	"bootstrapper": "@nativescript/plugin-seed",
+	"dependencies": {
+		"@nativescript/hook": "^2.0.0"
+	}
+}

--- a/packages/detox/platforms/android/AndroidManifest.xml
+++ b/packages/detox/platforms/android/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+	<application android:usesCleartextTraffic="true"></application>
+</manifest>

--- a/packages/detox/platforms/android/androidTest/java/com/tns/DetoxTest.java
+++ b/packages/detox/platforms/android/androidTest/java/com/tns/DetoxTest.java
@@ -1,0 +1,24 @@
+package com.tns;
+
+import com.wix.detox.Detox;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class DetoxTest {
+
+    @Rule
+    public ActivityTestRule<com.tns.NativeScriptActivity> mActivityRule = new ActivityTestRule<>(com.tns.NativeScriptActivity.class, false, false);
+
+    @Test
+    public void runDetoxTests() {
+        Detox.runTests(mActivityRule);
+    }
+}

--- a/packages/detox/platforms/android/androidTest/java/com/tns/DetoxTestRunner.java
+++ b/packages/detox/platforms/android/androidTest/java/com/tns/DetoxTestRunner.java
@@ -1,0 +1,14 @@
+package com.tns;
+
+import android.app.Application;
+import android.content.Context;
+import androidx.test.runner.AndroidJUnitRunner;
+
+public class DetoxTestRunner extends AndroidJUnitRunner {
+
+    @Override
+    public Application newApplication(ClassLoader cl, String className, Context context)
+        throws IllegalAccessException, ClassNotFoundException, InstantiationException {
+        return super.newApplication(cl, com.tns.NativeScriptApplication.class.getName(), context);
+    }
+}

--- a/packages/detox/platforms/android/include.gradle
+++ b/packages/detox/platforms/android/include.gradle
@@ -1,0 +1,22 @@
+repositories {
+  maven { url "$rootDir/../../node_modules/detox/Detox-android"}
+}
+
+dependencies {
+  androidTestImplementation('com.wix:detox:+') { transitive = true }
+  androidTestImplementation 'com.squareup.okhttp3:okhttp:+'
+}
+
+android {
+  defaultConfig {
+    minSdkVersion 18
+    sourceSets {
+        androidTest.setRoot("${project.rootDir}/../../node_modules/@nativescript/detox/platforms/android/androidTest")
+        androidTest {
+            java.srcDirs = ["${project.rootDir}/../../node_modules/@nativescript/detox/platforms/android/androidTest/java"]
+        }
+    }
+    testBuildType System.getProperty('testBuildType', 'debug')
+    testInstrumentationRunner 'com.tns.DetoxTestRunner'
+  }
+}

--- a/packages/detox/postinstall.js
+++ b/packages/detox/postinstall.js
@@ -1,0 +1,1 @@
+require('@nativescript/hook')(__dirname).postinstall();

--- a/packages/detox/preuninstall.js
+++ b/packages/detox/preuninstall.js
@@ -1,0 +1,1 @@
+require('@nativescript/hook')(__dirname).preuninstall();

--- a/packages/detox/references.d.ts
+++ b/packages/detox/references.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../references.d.ts" />

--- a/packages/detox/scripts/detox-build.js
+++ b/packages/detox/scripts/detox-build.js
@@ -1,0 +1,7 @@
+module.exports = function(hookArgs, $projectData) {
+    if ($projectData.$options.argv.detox){
+        console.log("Detox build enabled.")
+        hookArgs.args.unshift('assembleAndroidTest')
+        hookArgs.args.push('-DtestBuildType=debug')
+    }
+}

--- a/packages/detox/scripts/enable-animations.js
+++ b/packages/detox/scripts/enable-animations.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var spawn = require('child_process').spawn;
+function shspawn(command) {
+   spawn('sh', ['-c', command], { stdio: 'inherit' });
+} 
+
+shspawn('adb shell settings put global window_animation_scale 1');
+shspawn('adb shell settings put global transition_animation_scale 1');
+shspawn('adb shell settings put global animator_duration_scale 1');

--- a/packages/detox/tsconfig.json
+++ b/packages/detox/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"rootDir": ".",
+		"allowJs": true,
+		"assets": [
+			"**/*.sh"
+		]
+	},
+	"exclude": ["**/*.spec.ts", "angular"],
+}

--- a/tools/workspace-scripts.js
+++ b/tools/workspace-scripts.js
@@ -189,6 +189,13 @@ module.exports = {
 					description: '@nativescript/localize: Build',
 				},
 			},
+			// @nativescript/detox
+			detox: {
+				build: {
+					script: 'nx run detox:build.all',
+					description: '@nativescript/detox: Build',
+				},
+			},
 			'build-all': {
 				script: 'nx run all:build',
 				description: 'Build all packages',
@@ -270,6 +277,10 @@ module.exports = {
 			localize: {
 				script: 'nx run localize:focus',
 				description: 'Focus on @nativescript/localize',
+			},
+			detox: {
+				script: 'nx run detox:focus',
+				description: 'Focus on @nativescript/detox',
 			},
 			reset: {
 				script: 'nx run all:focus',

--- a/workspace.json
+++ b/workspace.json
@@ -220,7 +220,8 @@
 							"nx run social-share:build.all",
 							"nx run auto-fit-text:build.all",
 							"nx run animated-circle:build.all",
-							"nx run localize:build.all"
+							"nx run localize:build.all",
+							"nx run detox:build.all"
 						],
 						"parallel": false
 					}
@@ -877,6 +878,49 @@
 					"outputs": ["dist/packages"],
 					"options": {
 						"commands": ["nx g @nativescript/plugin-tools:focus-packages localize"],
+						"parallel": false
+					}
+				}
+			}
+		},
+		"detox": {
+			"root": "packages/detox",
+			"sourceRoot": "packages/detox",
+			"projectType": "library",
+			"schematics": {},
+			"architect": {
+				"build": {
+					"builder": "@nrwl/node:package",
+					"options": {
+						"outputPath": "dist/packages/detox",
+						"tsConfig": "packages/detox/tsconfig.json",
+						"packageJson": "packages/detox/package.json",
+						"main": "packages/detox/index.ts",
+						"assets": [
+							"packages/detox/*.md",
+							"packages/detox/index.d.ts",
+							"LICENSE",
+							{
+								"glob": "**/*",
+								"input": "packages/detox/platforms/",
+								"output": "./platforms/"
+							}
+						]
+					}
+				},
+				"build.all": {
+					"builder": "@nrwl/workspace:run-commands",
+					"outputs": ["dist/packages"],
+					"options": {
+						"commands": ["nx run detox:build", "node tools/scripts/build-finish.ts detox"],
+						"parallel": false
+					}
+				},
+				"focus": {
+					"builder": "@nrwl/workspace:run-commands",
+					"outputs": ["dist/packages"],
+					"options": {
+						"commands": ["nx g @nativescript/plugin-tools:focus-packages detox"],
 						"parallel": false
 					}
 				}


### PR DESCRIPTION
I have continued where @rigor789 left off and made his Detox work into a plugin. I am not sure if the `@nativescript` scope is the best place for this plugin, please let me know if it isn't.

~~**In order to use `testID` this PR in core must be implemented https://github.com/NativeScript/NativeScript/pull/8944**~~

**UPDATE:** I decided not to include the ability to use `testID` in favor of waiting for https://github.com/NativeScript/NativeScript/pull/8909 to be merged as it will incorporate `accessibilityIdentifier` and `accessibilityLabel` properties which will correspond with [Detox's](https://github.com/wix/Detox/blob/master/docs/APIRef.Matchers.md) `by.id()` and `by.label()` respectively. So for right now, the matcher `by.id()` is not supported, but `by.label()` will work by default by using the already existing property `automationText`.

I have also remove all demo related files from this PR as Detox doesn't have a conventional demo.