### PR TITLE
Update Readme: i18n folder should be placed in "src" folder root, not…

### DIFF
--- a/packages/localize/README.md
+++ b/packages/localize/README.md
@@ -30,10 +30,10 @@ tns plugin add @nativescript/localize
 
 ## Usage
 
-Create a folder `i18n` in the `app` folder with the following structure:
+Create a folder `i18n` in the `src` folder with the following structure:
 
 ```
-app
+src
   | i18n
       | en.json           <-- english language
       | fr.default.json   <-- french language (default)


### PR DESCRIPTION
… app folder

Localize doesn't work when the i18n folder is in the app folder.  Its working when put in the src folder (tested)