### PR TITLE
fix(shared-notification-delegate): userNotificationCenterWillPresentN…

### DIFF
--- a/packages/shared-notification-delegate/index.ios.ts
+++ b/packages/shared-notification-delegate/index.ios.ts
@@ -1,202 +1,206 @@
 import { SharedNotificationDelegateCommon } from './common';
 
 type DeferedPromise<T> = {
-    promise: Promise<T>;
-    resolve: (value?: T | PromiseLike<T>) => void;
-    reject: (reason?: any) => void;
+	promise: Promise<T>;
+	resolve: (value?: T | PromiseLike<T>) => void;
+	reject: (reason?: any) => void;
 };
 function createDeferedPromise<T>(): DeferedPromise<T> {
-    const deferred: DeferedPromise<T> = {
-        promise: undefined,
-        reject: undefined,
-        resolve: undefined
-    };
+	const deferred: DeferedPromise<T> = {
+		promise: undefined,
+		reject: undefined,
+		resolve: undefined,
+	};
 
-    deferred.promise = new Promise<T>((resolve, reject) => {
-        deferred.resolve = resolve;
-        deferred.reject = reject;
-    });
-    return deferred;
+	deferred.promise = new Promise<T>((resolve, reject) => {
+		deferred.resolve = resolve;
+		deferred.reject = reject;
+	});
+	return deferred;
 }
 
 type StopNextPromise = {
-    stop: () => void,
-    next: () => void
+	stop: () => void;
+	next: () => void;
 } & DeferedPromise<boolean>;
 
 function createStopNextPromise(): StopNextPromise {
-    const deferred = createDeferedPromise<boolean>();
-    return {
-        ...deferred,
-        next: () => deferred.resolve(false),
-        stop: () => deferred.resolve(true)
-    };
+	const deferred = createDeferedPromise<boolean>();
+	return {
+		...deferred,
+		next: () => deferred.resolve(false),
+		stop: () => deferred.resolve(true),
+	};
 }
 
 @NativeClass()
 class UNUserNotificationCenterDelegateImpl extends NSObject implements UNUserNotificationCenterDelegate {
-    public static ObjCProtocols = [];
+	public static ObjCProtocols = [];
 
-    static new(): UNUserNotificationCenterDelegateImpl {
-        if (UNUserNotificationCenterDelegateImpl.ObjCProtocols.length === 0 && typeof (UNUserNotificationCenterDelegate) !== "undefined") {
-            UNUserNotificationCenterDelegateImpl.ObjCProtocols.push(UNUserNotificationCenterDelegate);
-        }
-        return <UNUserNotificationCenterDelegateImpl>super.new();
-    }
+	static new(): UNUserNotificationCenterDelegateImpl {
+		if (UNUserNotificationCenterDelegateImpl.ObjCProtocols.length === 0 && typeof UNUserNotificationCenterDelegate !== 'undefined') {
+			UNUserNotificationCenterDelegateImpl.ObjCProtocols.push(UNUserNotificationCenterDelegate);
+		}
+		return <UNUserNotificationCenterDelegateImpl>super.new();
+	}
 
-    private _owner: WeakRef<SharedNotificationDelegateImpl>;
+	private _owner: WeakRef<SharedNotificationDelegateImpl>;
 
-    public static initWithOwner(owner: WeakRef<SharedNotificationDelegateImpl>): UNUserNotificationCenterDelegateImpl {
-        const delegate = <UNUserNotificationCenterDelegateImpl>UNUserNotificationCenterDelegateImpl.new();
-        delegate._owner = owner;
-        return delegate;
-    }
+	public static initWithOwner(owner: WeakRef<SharedNotificationDelegateImpl>): UNUserNotificationCenterDelegateImpl {
+		const delegate = <UNUserNotificationCenterDelegateImpl>UNUserNotificationCenterDelegateImpl.new();
+		delegate._owner = owner;
+		return delegate;
+	}
 
-    public userNotificationCenterWillPresentNotificationWithCompletionHandler(center: UNUserNotificationCenter, notification: UNNotification, completionHandler: (p1: UNNotificationPresentationOptions) => void): void {
-        let promise = Promise.resolve(false);
-        const owner = this._owner.get();
-        if (owner) {
-            owner._observers.forEach(({ observer }) => {
-                if (observer.userNotificationCenterWillPresentNotificationWithCompletionHandler) {
-                    promise = promise.then((skip: boolean) => {
-                        if (skip) { return true; }
-                        const defPromise = createStopNextPromise();
-                        const childHandler: (p1: UNNotificationPresentationOptions) => void = (p1: UNNotificationPresentationOptions) => {
-                            defPromise.stop();
-                            completionHandler(p1);
-                        };
-                        try {
-                            observer.userNotificationCenterWillPresentNotificationWithCompletionHandler(center, notification, childHandler, defPromise.next);
-                        } catch (ignore) {
-                            defPromise.next();
-                        }
-                        return defPromise.promise;
-                    });
-                }
-            });
-            promise.then((handled: boolean) => {
-                if (!handled) {
-                    completionHandler(0);
-                }
-                return true;
-            });
-        }
-    }
+	public userNotificationCenterWillPresentNotificationWithCompletionHandler(center: UNUserNotificationCenter, notification: UNNotification, completionHandler: (p1: UNNotificationPresentationOptions) => void): void {
+		const owner = this._owner.get();
+		if (owner) {
+			let handled = false;
+			const next = () => (handled = handled ? handled : false);
+			const childHandler = (p1: UNNotificationPresentationOptions) => {
+				if (handled) {
+					return;
+				}
+				handled = true;
+				completionHandler(p1);
+			};
+			owner._observers.some(({ observer }) => {
+				if (observer.userNotificationCenterWillPresentNotificationWithCompletionHandler) {
+					try {
+						observer.userNotificationCenterWillPresentNotificationWithCompletionHandler(center, notification, childHandler, next);
+					} catch (ignore) {
+						next();
+					}
+				}
+				return handled;
+			});
+			if (!handled) {
+				if (!owner.disableUnhandledWarning) {
+					console.log('WARNING[shared-notification-delegate]: Notification was received for presentation but was not handled by any observer');
+				}
+				childHandler(0);
+			}
+		}
+	}
 
-    public userNotificationCenterOpenSettingsForNotification(center: UNUserNotificationCenter, notification: UNNotification): void {
-        let promise = Promise.resolve(false);
-        const owner = this._owner.get();
-        if (owner) {
-            owner._observers.forEach(({ observer }) => {
-                if (observer.userNotificationCenterOpenSettingsForNotification) {
-                    promise = promise.then((skip: boolean) => {
-                        if (skip) { return true; }
-                        const defPromise = createStopNextPromise();
-                        try {
-                            observer.userNotificationCenterOpenSettingsForNotification(center, notification, defPromise.stop, defPromise.next);
-                        } catch (ignore) {
-                            defPromise.next();
-                        }
-                        return defPromise.promise;
-                    });
-                }
-            });
-        }
-    }
+	public userNotificationCenterOpenSettingsForNotification(center: UNUserNotificationCenter, notification: UNNotification): void {
+		let promise = Promise.resolve(false);
+		const owner = this._owner.get();
+		if (owner) {
+			owner._observers.forEach(({ observer }) => {
+				if (observer.userNotificationCenterOpenSettingsForNotification) {
+					promise = promise.then((skip: boolean) => {
+						if (skip) {
+							return true;
+						}
+						const defPromise = createStopNextPromise();
+						try {
+							observer.userNotificationCenterOpenSettingsForNotification(center, notification, defPromise.stop, defPromise.next);
+						} catch (ignore) {
+							defPromise.next();
+						}
+						return defPromise.promise;
+					});
+				}
+			});
+		}
+	}
 
-    public userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () => void): void {
-        let promise = Promise.resolve(false);
-        const owner = this._owner.get();
-        if (owner) {
-            owner._observers.forEach(({ observer }) => {
-                if (observer.userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler) {
-                    promise = promise.then((skip: boolean) => {
-                        if (skip) { return true; }
-                        const defPromise = createStopNextPromise();
-                        const childHandler: () => void = () => {
-                            defPromise.stop();
-                            completionHandler();
-                        };
-                        try {
-                            observer.userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler(center, response, childHandler, defPromise.next);
-                        } catch (ignore) {
-                            defPromise.next();
-                        }
-                        return defPromise.promise;
-                    });
-                }
-            });
-            promise.then((handled: boolean) => {
-                if (!handled) {
-                    if (!owner.disableUnhandledWarning) {
-                        console.log("WARNING[shared-notification-delegate]: Notification was received but was not handled by any observer");
-                    }
-                    completionHandler();
-                }
-                return true;
-            });
-        }
-    }
+	public userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () => void): void {
+		let promise = Promise.resolve(false);
+		const owner = this._owner.get();
+		if (owner) {
+			owner._observers.forEach(({ observer }) => {
+				if (observer.userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler) {
+					promise = promise.then((skip: boolean) => {
+						if (skip) {
+							return true;
+						}
+						const defPromise = createStopNextPromise();
+						const childHandler: () => void = () => {
+							defPromise.stop();
+							completionHandler();
+						};
+						try {
+							observer.userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler(center, response, childHandler, defPromise.next);
+						} catch (ignore) {
+							defPromise.next();
+						}
+						return defPromise.promise;
+					});
+				}
+			});
+			promise.then((handled: boolean) => {
+				if (!handled) {
+					if (!owner.disableUnhandledWarning) {
+						console.log('WARNING[shared-notification-delegate]: Notification was received but was not handled by any observer');
+					}
+					completionHandler();
+				}
+				return true;
+			});
+		}
+	}
 }
 
 export interface DelegateObserver {
-    userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler?(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () => void, next: () => void): void;
-    userNotificationCenterOpenSettingsForNotification?(center: UNUserNotificationCenter, notification: UNNotification, stop: () => void, next: () => void): void;
-    userNotificationCenterWillPresentNotificationWithCompletionHandler?(center: UNUserNotificationCenter, notification: UNNotification, completionHandler: (p1: UNNotificationPresentationOptions) => void, next: () => void): void;
-    /**
-     * if set to not null/undefined, will ensure only one is registered
-     */
-    observerUniqueKey?: any;
+	userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler?(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () => void, next: () => void): void;
+	userNotificationCenterOpenSettingsForNotification?(center: UNUserNotificationCenter, notification: UNNotification, stop: () => void, next: () => void): void;
+	userNotificationCenterWillPresentNotificationWithCompletionHandler?(center: UNUserNotificationCenter, notification: UNNotification, completionHandler: (p1: UNNotificationPresentationOptions) => void, next: () => void): void;
+	/**
+	 * if set to not null/undefined, will ensure only one is registered
+	 */
+	observerUniqueKey?: any;
 }
 export class SharedNotificationDelegateImpl extends SharedNotificationDelegateCommon {
-    _observers: Array<{ observer: DelegateObserver, priority: number }> = [];
-    disableUnhandledWarning = false;
-    private delegate: UNUserNotificationCenterDelegateImpl;
+	_observers: Array<{ observer: DelegateObserver; priority: number }> = [];
+	disableUnhandledWarning = false;
+	private delegate: UNUserNotificationCenterDelegateImpl;
 
-    constructor() {
-        super();
-        if (SharedNotificationDelegateImpl.isUNUserNotificationCenterAvailable()) {
-            this.delegate = UNUserNotificationCenterDelegateImpl.initWithOwner(new WeakRef(this));
-            UNUserNotificationCenter.currentNotificationCenter().delegate = this.delegate;
-        }
-    }
+	constructor() {
+		super();
+		if (SharedNotificationDelegateImpl.isUNUserNotificationCenterAvailable()) {
+			this.delegate = UNUserNotificationCenterDelegateImpl.initWithOwner(new WeakRef(this));
+			UNUserNotificationCenter.currentNotificationCenter().delegate = this.delegate;
+		}
+	}
 
-    static isUNUserNotificationCenterAvailable(): boolean {
-        try {
-            // available since iOS 10
-            return !!UNUserNotificationCenter;
-        } catch (ignore) {
-            return false;
-        }
-    }
+	static isUNUserNotificationCenterAvailable(): boolean {
+		try {
+			// available since iOS 10
+			return !!UNUserNotificationCenter;
+		} catch (ignore) {
+			return false;
+		}
+	}
 
-    addObserver(observer: DelegateObserver, priority: number = 100) {
-        if (observer.observerUniqueKey != null) {
-            this.removeObserverByUniqueKey(observer.observerUniqueKey);
-        }
-        this._observers.push({ observer, priority });
-        this.sortObservers();
-    }
+	addObserver(observer: DelegateObserver, priority: number = 100) {
+		if (observer.observerUniqueKey != null) {
+			this.removeObserverByUniqueKey(observer.observerUniqueKey);
+		}
+		this._observers.push({ observer, priority });
+		this.sortObservers();
+	}
 
-    removeObserver(observer: DelegateObserver) {
-        this._observers = this._observers.filter((v) => v.observer !== observer);
-    }
+	removeObserver(observer: DelegateObserver) {
+		this._observers = this._observers.filter((v) => v.observer !== observer);
+	}
 
-    removeObserverByUniqueKey(key: string) {
-        if (key == null) {
-            console.log("SharedNotificationDelegate Warning: tried to remove null/undefined keys.");
-            return;
-        }
-        this._observers = this._observers.filter((v) => v.observer.observerUniqueKey !== key);
-    }
+	removeObserverByUniqueKey(key: string) {
+		if (key == null) {
+			console.log('SharedNotificationDelegate Warning: tried to remove null/undefined keys.');
+			return;
+		}
+		this._observers = this._observers.filter((v) => v.observer.observerUniqueKey !== key);
+	}
 
-    clearObservers() {
-        this._observers = [];
-    }
+	clearObservers() {
+		this._observers = [];
+	}
 
-    private sortObservers() {
-        this._observers.sort((a, b) => a.priority > b.priority ? 1 : (a.priority < b.priority ? -1 : 0));
-    }
+	private sortObservers() {
+		this._observers.sort((a, b) => (a.priority > b.priority ? 1 : a.priority < b.priority ? -1 : 0));
+	}
 }
 
 const instance = new SharedNotificationDelegateImpl();


### PR DESCRIPTION
…otificationWithCompletionHandler must be synchronous

According to [Apple Documentation](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649518-usernotificationcenter):
>**completionHandler**
>The block to execute with the presentation option for the notification. **Always execute this block at some point during your implementation of this method**. Use the options parameter to specify how you want the system to alert the user, if at all. This block has no return value and takes the following parameter:

Since we were using Promises to handle this, microtasks were running outside the implementation and sometimes resulting in a crash. As a note, userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler appears to be asynchronous, so no change is needed

Fixes #29

BREAKING CHANGES:

When implementing `userNotificationCenterWillPresentNotificationWithCompletionHandler`, ensure to call `completionHandler` synchronously, otherwise it will be sent to another observer or `completionHandler(0)` will be called.