### PR TITLE
fix: missing picker plugin in build all command

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -221,7 +221,8 @@
 							"nx run auto-fit-text:build.all",
 							"nx run animated-circle:build.all",
 							"nx run localize:build.all",
-							"nx run detox:build.all"
+							"nx run detox:build.all",
+							"nx run picker:build.all"
 						],
 						"parallel": false
 					}


### PR DESCRIPTION

## What is the current behavior?
After selecting @nativescript.build-all all of the plugins are starting to build except @nativescript/picker.

## What is the new behavior?
After selecting @nativescript.build-all all of the plugins are starting to build.

Fixes #99