### PR TITLE
Support for iOS 14 inline calendar view + firstWeekday

### DIFF
--- a/packages/datetimepicker/common.ts
+++ b/packages/datetimepicker/common.ts
@@ -1,121 +1,120 @@
-import { View, ContentView, Page, Color, Frame } from "@nativescript/core";
-import {
-    DateTimePicker as DateTimePickerDefinition,
-    DateTimePickerStyle as DateTimePickerStyleDefinition
-} from ".";
+import { View, ContentView, Page, Color, Frame } from '@nativescript/core';
+import { DateTimePicker as DateTimePickerDefinition, DateTimePickerStyle as DateTimePickerStyleDefinition } from '.';
 
-export const CSS_NAME = "date-time-picker";
-export const SPINNERS_CSS_NAME = "date-time-picker-spinners";
-export const BUTTONS_CSS_NAME = "date-time-picker-buttons";
-export const BUTTON_OK_CSS_NAME = "date-time-picker-button-ok";
-export const BUTTON_CANCEL_CSS_NAME = "date-time-picker-button-cancel";
+export const CSS_NAME = 'date-time-picker';
+export const SPINNERS_CSS_NAME = 'date-time-picker-spinners';
+export const BUTTONS_CSS_NAME = 'date-time-picker-buttons';
+export const BUTTON_OK_CSS_NAME = 'date-time-picker-button-ok';
+export const BUTTON_CANCEL_CSS_NAME = 'date-time-picker-button-cancel';
 
 export class DateTimePickerBase implements DateTimePickerDefinition {
-    static pickDate(options: DatePickerOptions, style?: DateTimePickerStyleDefinition): Promise<Date> {
-        return Promise.resolve(null);
-    }
-    static pickTime(options: TimePickerOptions, style?: DateTimePickerStyleDefinition): Promise<Date> {
-        return Promise.resolve(null);
-    }
+	static pickDate(options: DatePickerOptions, style?: DateTimePickerStyleDefinition): Promise<Date> {
+		return Promise.resolve(null);
+	}
+	static pickTime(options: TimePickerOptions, style?: DateTimePickerStyleDefinition): Promise<Date> {
+		return Promise.resolve(null);
+	}
 }
 
 export interface DatePickerOptions extends PickerOptions {
-    date?: Date;
-    minDate?: Date;
-    maxDate?: Date;
+	date?: Date;
+	minDate?: Date;
+	maxDate?: Date;
+	iosPreferredDatePickerStyle?: number;
 }
 
 export interface TimePickerOptions extends PickerOptions {
-    time?: Date;
-    is24Hours?: boolean;
+	time?: Date;
+	is24Hours?: boolean;
+	iosPreferredDatePickerStyle?: number;
 }
 
 export interface PickerOptions {
-    context: any;
-    locale?: string;
-    title?: string;
-    okButtonText?: string;
-    cancelButtonText?: string;
+	context: any;
+	locale?: string;
+	title?: string;
+	okButtonText?: string;
+	cancelButtonText?: string;
 }
 
 export class DateTimePickerStyleBase implements DateTimePickerStyleDefinition {
-    dialogBackgroundColor: Color;
-    titleTextColor: Color;
-    spinnersTextColor: Color;
-    spinnersBackgroundColor: Color;
-    buttonsTextColor: Color;
-    buttonsBackgroundColor: Color;
-    buttonOkTextColor: Color;
-    buttonOkBackgroundColor: Color;
-    buttonCancelTextColor: Color;
-    buttonCancelBackgroundColor: Color;
+	dialogBackgroundColor: Color;
+	titleTextColor: Color;
+	spinnersTextColor: Color;
+	spinnersBackgroundColor: Color;
+	buttonsTextColor: Color;
+	buttonsBackgroundColor: Color;
+	buttonOkTextColor: Color;
+	buttonOkBackgroundColor: Color;
+	buttonCancelTextColor: Color;
+	buttonCancelBackgroundColor: Color;
 
-    static create(view: View): DateTimePickerStyleBase {
-        let style = new DateTimePickerStyleBase();
-        const pickerColors = getColorsForClassName(view, CSS_NAME);
-        const pickerSpinnersColors = getColorsForClassName(view, SPINNERS_CSS_NAME);
-        const pickerButtonsColors = getColorsForClassName(view, BUTTONS_CSS_NAME);
-        const pickerButtonOkColors = getColorsForClassName(view, BUTTON_OK_CSS_NAME);
-        const pickerButtonCancelColors = getColorsForClassName(view, BUTTON_CANCEL_CSS_NAME);
-        style.dialogBackgroundColor = pickerColors.backgroundColor;
-        style.titleTextColor = pickerColors.color;
-        style.spinnersBackgroundColor = pickerSpinnersColors.backgroundColor;
-        style.spinnersTextColor = pickerSpinnersColors.color;
-        style.buttonsBackgroundColor = pickerButtonsColors.backgroundColor;
-        style.buttonsTextColor = pickerButtonsColors.color;
-        style.buttonOkBackgroundColor = pickerButtonOkColors.backgroundColor;
-        style.buttonOkTextColor = pickerButtonOkColors.color;
-        style.buttonCancelBackgroundColor = pickerButtonCancelColors.backgroundColor;
-        style.buttonCancelTextColor = pickerButtonCancelColors.color;
-        return style;
-    }
+	static create(view: View): DateTimePickerStyleBase {
+		let style = new DateTimePickerStyleBase();
+		const pickerColors = getColorsForClassName(view, CSS_NAME);
+		const pickerSpinnersColors = getColorsForClassName(view, SPINNERS_CSS_NAME);
+		const pickerButtonsColors = getColorsForClassName(view, BUTTONS_CSS_NAME);
+		const pickerButtonOkColors = getColorsForClassName(view, BUTTON_OK_CSS_NAME);
+		const pickerButtonCancelColors = getColorsForClassName(view, BUTTON_CANCEL_CSS_NAME);
+		style.dialogBackgroundColor = pickerColors.backgroundColor;
+		style.titleTextColor = pickerColors.color;
+		style.spinnersBackgroundColor = pickerSpinnersColors.backgroundColor;
+		style.spinnersTextColor = pickerSpinnersColors.color;
+		style.buttonsBackgroundColor = pickerButtonsColors.backgroundColor;
+		style.buttonsTextColor = pickerButtonsColors.color;
+		style.buttonOkBackgroundColor = pickerButtonOkColors.backgroundColor;
+		style.buttonOkTextColor = pickerButtonOkColors.color;
+		style.buttonCancelBackgroundColor = pickerButtonCancelColors.backgroundColor;
+		style.buttonCancelTextColor = pickerButtonCancelColors.color;
+		return style;
+	}
 }
 
 export function getCurrentPage(): Page {
-    let topmostFrame = Frame.topmost();
-    if (topmostFrame) {
-        return topmostFrame.currentPage;
-    }
-    return undefined;
+	let topmostFrame = Frame.topmost();
+	if (topmostFrame) {
+		return topmostFrame.currentPage;
+	}
+	return undefined;
 }
 
-function getColorsForClassName(view: View, className: string): { color: Color, backgroundColor: Color } {
-    let color: Color;
-    let backgroundColor: Color;
-    let tempView = new ContentView();
-    const ngKey = Object.keys(view).find(key => key.startsWith('_ngcontent'));
-    const vueKey = Object.keys(view).find(key => key.startsWith('data-v'));
-    if (ngKey) {
-        tempView[ngKey] = view[ngKey];
-    }
-    if (vueKey) {
-        tempView[vueKey] = view[vueKey];
-    }
-    if (view.className) {
-        let classNames = view.className.split(' ');
-        classNames.forEach(element => {
-            tempView.cssClasses.add(element);
-        });
-    }
-    if (className) {
-        tempView.cssClasses.add(className);
-    }
-    applySelectors(tempView, (v) => {
-        color = v.color;
-        backgroundColor = <Color>v.backgroundColor;
-    });
-    return { color: color, backgroundColor: backgroundColor };
+function getColorsForClassName(view: View, className: string): { color: Color; backgroundColor: Color } {
+	let color: Color;
+	let backgroundColor: Color;
+	let tempView = new ContentView();
+	const ngKey = Object.keys(view).find((key) => key.startsWith('_ngcontent'));
+	const vueKey = Object.keys(view).find((key) => key.startsWith('data-v'));
+	if (ngKey) {
+		tempView[ngKey] = view[ngKey];
+	}
+	if (vueKey) {
+		tempView[vueKey] = view[vueKey];
+	}
+	if (view.className) {
+		let classNames = view.className.split(' ');
+		classNames.forEach((element) => {
+			tempView.cssClasses.add(element);
+		});
+	}
+	if (className) {
+		tempView.cssClasses.add(className);
+	}
+	applySelectors(tempView, (v) => {
+		color = v.color;
+		backgroundColor = <Color>v.backgroundColor;
+	});
+	return { color: color, backgroundColor: backgroundColor };
 }
 
 function applySelectors<T extends View>(view: T, callback: (view: T) => void) {
-    let currentPage = getCurrentPage();
-    if (currentPage) {
-        let styleScope = currentPage['_styleScope'];
-        if (styleScope) {
-            view['_inheritStyleScope'](styleScope);
-            view.onLoaded();
-            callback(view);
-            view.onUnloaded();
-        }
-    }
+	let currentPage = getCurrentPage();
+	if (currentPage) {
+		let styleScope = currentPage['_styleScope'];
+		if (styleScope) {
+			view['_inheritStyleScope'](styleScope);
+			view.onLoaded();
+			callback(view);
+			view.onUnloaded();
+		}
+	}
 }

--- a/packages/datetimepicker/common.ts
+++ b/packages/datetimepicker/common.ts
@@ -21,6 +21,7 @@ export interface DatePickerOptions extends PickerOptions {
 	minDate?: Date;
 	maxDate?: Date;
 	iosPreferredDatePickerStyle?: number;
+	firstWeekday?: number;
 }
 
 export interface TimePickerOptions extends PickerOptions {

--- a/packages/datetimepicker/index.d.ts
+++ b/packages/datetimepicker/index.d.ts
@@ -1,4 +1,4 @@
-import { Color, View } from "@nativescript/core";
+import { Color, View } from '@nativescript/core';
 export * from './utils';
 export * from './ui';
 
@@ -6,15 +6,15 @@ export * from './ui';
  * Represents a class that provides methods for picking date and time.
  */
 export class DateTimePicker {
-    /**
-     * Picks a date from a dialog picker initialized with the provided options and styled with the optionally provided style.
-     */
-    static pickDate(options: DatePickerOptions, style?: DateTimePickerStyle): Promise<Date>;
+	/**
+	 * Picks a date from a dialog picker initialized with the provided options and styled with the optionally provided style.
+	 */
+	static pickDate(options: DatePickerOptions, style?: DateTimePickerStyle): Promise<Date>;
 
-    /**
-     * Picks a time from a dialog picker initialized with the provided options and styled with the optionally provided style.
-     */
-    static pickTime(options: TimePickerOptions, style?: DateTimePickerStyle): Promise<Date>;
+	/**
+	 * Picks a time from a dialog picker initialized with the provided options and styled with the optionally provided style.
+	 */
+	static pickTime(options: TimePickerOptions, style?: DateTimePickerStyle): Promise<Date>;
 }
 
 /**
@@ -22,20 +22,25 @@ export class DateTimePicker {
  * {@link DateTimePicker}'s {@link pickDate} method.
  */
 export interface DatePickerOptions extends PickerOptions {
-    /**
-     * The date that will be displayed in the picker, (if not provided, the picker will display today).
-     */
-    date?: Date;
+	/**
+	 * The date that will be displayed in the picker, (if not provided, the picker will display today).
+	 */
+	date?: Date;
 
-    /**
-     * The minimum date that can be selected.
-     */
-    minDate?: Date;
+	/**
+	 * The minimum date that can be selected.
+	 */
+	minDate?: Date;
 
-    /**
-     * The maximum date that can be selected.
-     */
-    maxDate?: Date;
+	/**
+	 * The maximum date that can be selected.
+	 */
+	maxDate?: Date;
+
+	/**
+	 * iOS only: date picker style (from iOS 13.4)
+	 */
+	iosPreferredDatePickerStyle?: number;
 }
 
 /**
@@ -43,15 +48,15 @@ export interface DatePickerOptions extends PickerOptions {
  * {@link DateTimePicker}'s {@link pickTime} method.
  */
 export interface TimePickerOptions extends PickerOptions {
-    /**
-     * The time that will be displayed in the picker, (if not provided, the picker will display now).
-     */
-    time?: Date;
+	/**
+	 * The time that will be displayed in the picker, (if not provided, the picker will display now).
+	 */
+	time?: Date;
 
-    /**
-     * This value will be used only on Android to determine whether the picker will be in 12 or 24 hour format.
-     */
-    is24Hours?: boolean;
+	/**
+	 * This value will be used only on Android to determine whether the picker will be in 12 or 24 hour format.
+	 */
+	is24Hours?: boolean;
 }
 
 /**
@@ -59,30 +64,30 @@ export interface TimePickerOptions extends PickerOptions {
  * {@link DateTimePicker}'s {@link pickDate} and {@link pickTime} methods.
  */
 export interface PickerOptions {
-    /**
-     * View's context.
-     */
-    context: any;
+	/**
+	 * View's context.
+	 */
+	context: any;
 
-    /**
-     * Identifier of a locale that will be used to localize month names and am/pm texts.
-     */
-    locale?: string;
+	/**
+	 * Identifier of a locale that will be used to localize month names and am/pm texts.
+	 */
+	locale?: string;
 
-    /**
-     * Text that will be displayed as title of the picker, default is undefined.
-     */
-    title?: string;
+	/**
+	 * Text that will be displayed as title of the picker, default is undefined.
+	 */
+	title?: string;
 
-    /**
-     * Text for the confirmation button of the picker (default is OK on iOS, localized version of OK on android (based on the devices locale settings)).
-     */
-    okButtonText?: string;
+	/**
+	 * Text for the confirmation button of the picker (default is OK on iOS, localized version of OK on android (based on the devices locale settings)).
+	 */
+	okButtonText?: string;
 
-    /**
-     * Text for the cancel button of the picker (default is Cancel on iOS, localized version of Cancel on android (based on the devices locale settings)).
-     */
-    cancelButtonText?: string;
+	/**
+	 * Text for the cancel button of the picker (default is Cancel on iOS, localized version of Cancel on android (based on the devices locale settings)).
+	 */
+	cancelButtonText?: string;
 }
 
 /**
@@ -90,58 +95,58 @@ export interface PickerOptions {
  * {@link DateTimePicker}'s {@link pickDate} and {@link pickTime} methods.
  */
 export class DateTimePickerStyle {
-    /**
-     * Color to be used as a background of the dialog picker.
-     */
-    dialogBackgroundColor: Color;
+	/**
+	 * Color to be used as a background of the dialog picker.
+	 */
+	dialogBackgroundColor: Color;
 
-    /**
-     * Color to be used for the title text.
-     */
-    titleTextColor: Color;
+	/**
+	 * Color to be used for the title text.
+	 */
+	titleTextColor: Color;
 
-    /**
-     * Color to be used for the texts of the date/time spinners.
-     */
-    spinnersTextColor: Color;
+	/**
+	 * Color to be used for the texts of the date/time spinners.
+	 */
+	spinnersTextColor: Color;
 
-    /**
-     * Color to be used as a background of the date/time spinners.
-     */
-    spinnersBackgroundColor: Color;
+	/**
+	 * Color to be used as a background of the date/time spinners.
+	 */
+	spinnersBackgroundColor: Color;
 
-    /**
-     * Color to be used for the texts of the ok/cancel buttons.
-     */
-    buttonsTextColor: Color;
+	/**
+	 * Color to be used for the texts of the ok/cancel buttons.
+	 */
+	buttonsTextColor: Color;
 
-    /**
-     * Color to be used as a background of the ok/cancel buttons.
-     */
-    buttonsBackgroundColor: Color;
+	/**
+	 * Color to be used as a background of the ok/cancel buttons.
+	 */
+	buttonsBackgroundColor: Color;
 
-    /**
-     * Color to be used for the texts of the ok button.
-     */
-    buttonOkTextColor: Color;
+	/**
+	 * Color to be used for the texts of the ok button.
+	 */
+	buttonOkTextColor: Color;
 
-    /**
-     * Color to be used as a background of the ok button.
-     */
-    buttonOkBackgroundColor: Color;
+	/**
+	 * Color to be used as a background of the ok button.
+	 */
+	buttonOkBackgroundColor: Color;
 
-    /**
-     * Color to be used for the texts of the cancel button.
-     */
-    buttonCancelTextColor: Color;
+	/**
+	 * Color to be used for the texts of the cancel button.
+	 */
+	buttonCancelTextColor: Color;
 
-    /**
-     * Color to be used as a background of the cancel button.
-     */
-    buttonCancelBackgroundColor: Color;
+	/**
+	 * Color to be used as a background of the cancel button.
+	 */
+	buttonCancelBackgroundColor: Color;
 
-    /**
-     * Creates a style based on any css provided. The parameter is a View with the properly setup css class name.
-     */
-    static create(view: View): DateTimePickerStyle;
+	/**
+	 * Creates a style based on any css provided. The parameter is a View with the properly setup css class name.
+	 */
+	static create(view: View): DateTimePickerStyle;
 }

--- a/packages/datetimepicker/index.d.ts
+++ b/packages/datetimepicker/index.d.ts
@@ -38,6 +38,11 @@ export interface DatePickerOptions extends PickerOptions {
 	maxDate?: Date;
 
 	/**
+	 * First day of week
+	 */
+	firstWeekday?: number;
+
+	/**
 	 * iOS only: date picker style (from iOS 13.4)
 	 */
 	iosPreferredDatePickerStyle?: number;

--- a/packages/datetimepicker/index.ios.ts
+++ b/packages/datetimepicker/index.ios.ts
@@ -44,7 +44,7 @@ export class DateTimePicker extends DateTimePickerBase {
 		const pickerView = UIDatePicker.alloc().initWithFrame(CGRectZero);
 		pickerView.datePickerMode = UIDatePickerMode.Date;
 		if (this.SUPPORT_DATE_PICKER_STYLE) {
-			pickerView.preferredDatePickerStyle = this.DEFAULT_DATE_PICKER_STYLE;
+			pickerView.preferredDatePickerStyle = options.iosPreferredDatePickerStyle !== undefined ? options.iosPreferredDatePickerStyle : this.DEFAULT_DATE_PICKER_STYLE;
 		}
 		const date = options.date ? options.date : getDateToday();
 		pickerView.date = date;
@@ -64,7 +64,7 @@ export class DateTimePicker extends DateTimePickerBase {
 		const pickerView = UIDatePicker.alloc().initWithFrame(CGRectZero);
 		pickerView.datePickerMode = UIDatePickerMode.Time;
 		if (this.SUPPORT_DATE_PICKER_STYLE) {
-			pickerView.preferredDatePickerStyle = this.DEFAULT_DATE_PICKER_STYLE;
+			pickerView.preferredDatePickerStyle = options.iosPreferredDatePickerStyle !== undefined ? options.iosPreferredDatePickerStyle : this.DEFAULT_DATE_PICKER_STYLE;
 		}
 		const time = options.time ? options.time : getDateNow();
 		pickerView.date = time;

--- a/packages/datetimepicker/index.ios.ts
+++ b/packages/datetimepicker/index.ios.ts
@@ -9,14 +9,15 @@ export class DateTimePickerStyle extends DateTimePickerStyleBase {}
 export class DateTimePicker extends DateTimePickerBase {
 	private static readonly SUPPORT_DATE_PICKER_STYLE = parseFloat(Device.osVersion) >= 14.0;
 	private static readonly SUPPORT_TEXT_COLOR = parseFloat(Device.osVersion) < 14.0;
-	private static readonly DEFAULT_DATE_PICKER_STYLE = 1;
+	private static readonly DEFAULT_DATE_PICKER_STYLE = parseFloat(Device.osVersion) >= 14.0 ? 3 : 1;
 
-	public static PICKER_DEFAULT_MESSAGE_HEIGHT = 192;
+	public static PICKER_DEFAULT_MESSAGE_HEIGHT = parseFloat(Device.osVersion) >= 14.0 ? 300 : 192;
 	public static PICKER_WIDTH_INSETS = 16;
 	public static PICKER_WIDTH_PAD = 304;
+	public static PICKER_DEFAULT_OFFSET = 16;
 	public static PICKER_DEFAULT_TITLE_OFFSET = 26.5;
 	public static PICKER_DEFAULT_TITLE_HEIGHT = 16;
-	public static PICKER_DEFAULT_MESSAGE = '\n\n\n\n\n\n\n\n\n';
+	public static PICKER_DEFAULT_MESSAGE = parseFloat(Device.osVersion) >= 14.0 ? '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' : '\n\n\n\n\n\n\n\n\n';
 
 	static pickDate(options: DatePickerOptions, style?: DateTimePickerStyle): Promise<Date> {
 		const pickDate = new Promise<Date>((resolve) => {
@@ -56,6 +57,9 @@ export class DateTimePicker extends DateTimePickerBase {
 		}
 		if (options.locale) {
 			pickerView.locale = LocalizationUtils.createNativeLocale(options.locale);
+			if (options.firstWeekday !== undefined) {
+				pickerView.calendar = LocalizationUtils.createNativeCalendar(options.locale, options.firstWeekday);
+			}
 		}
 		return pickerView;
 	}
@@ -77,10 +81,10 @@ export class DateTimePicker extends DateTimePickerBase {
 	static _createNativeDialog(nativePicker: UIDatePicker, options: PickerOptions, style: DateTimePickerStyle, callback: Function) {
 		const alertTitle = options.title ? options.title : '';
 		const alertController = UIAlertController.alertControllerWithTitleMessagePreferredStyle(alertTitle, DateTimePicker.PICKER_DEFAULT_MESSAGE, UIAlertControllerStyle.ActionSheet);
-		const alertSize = Math.min(alertController.view.frame.size.width, alertController.view.frame.size.height);
+		const alertSize = nativePicker.preferredDatePickerStyle === 3 ? 280 : Math.min(alertController.view.frame.size.width, alertController.view.frame.size.height);
 		const pickerViewWidth = UIDevice.currentDevice.userInterfaceIdiom === UIUserInterfaceIdiom.Pad ? DateTimePicker.PICKER_WIDTH_PAD : alertSize - DateTimePicker.PICKER_WIDTH_INSETS;
 
-		let pickerContainerFrameTop = DateTimePicker.PICKER_DEFAULT_TITLE_OFFSET;
+		let pickerContainerFrameTop = options.title ? DateTimePicker.PICKER_DEFAULT_TITLE_OFFSET : DateTimePicker.PICKER_DEFAULT_OFFSET;
 		if (options.title) {
 			pickerContainerFrameTop += DateTimePicker.PICKER_DEFAULT_TITLE_HEIGHT;
 		}
@@ -95,7 +99,8 @@ export class DateTimePicker extends DateTimePickerBase {
 		DateTimePicker._applyDialogSpinnersColors(nativePicker, pickerContainer, spinnersTextColor, spinnersBackgroundColor);
 
 		const pickerView = nativePicker;
-		pickerView.frame = CGRectMake(0, 0, pickerViewWidth, pickerViewHeight);
+		const left = (alertController.view.frame.size.width - pickerViewWidth) / 2 - DateTimePicker.PICKER_WIDTH_INSETS;
+		pickerView.frame = CGRectMake(left, 0, pickerViewWidth, pickerViewHeight);
 		pickerContainer.addSubview(pickerView);
 		DateTimePicker._clearVibrancyEffects(alertController.view);
 
@@ -110,8 +115,13 @@ export class DateTimePicker extends DateTimePickerBase {
 		pickerContainer.rightAnchor.constraintEqualToAnchor(alertController.view.rightAnchor).active = true;
 		pickerContainer.bottomAnchor.constraintEqualToAnchor(alertController.view.bottomAnchor).active = true;
 
-		pickerView.leftAnchor.constraintLessThanOrEqualToAnchorConstant(pickerContainer.leftAnchor, DateTimePicker.PICKER_WIDTH_INSETS).active = true;
-		pickerView.rightAnchor.constraintLessThanOrEqualToAnchorConstant(pickerContainer.rightAnchor, DateTimePicker.PICKER_WIDTH_INSETS).active = true;
+		if (nativePicker.preferredDatePickerStyle === 3) {
+			pickerView.centerXAnchor.constraintEqualToAnchor(pickerContainer.centerXAnchor).active = true;
+			// pickerView.leftAnchor.constraintEqualToAnchorConstant(pickerContainer.leftAnchor, left).active = true;
+		} else {
+			pickerView.leftAnchor.constraintLessThanOrEqualToAnchorConstant(pickerContainer.leftAnchor, DateTimePicker.PICKER_WIDTH_INSETS).active = true;
+			pickerView.rightAnchor.constraintLessThanOrEqualToAnchorConstant(pickerContainer.rightAnchor, DateTimePicker.PICKER_WIDTH_INSETS).active = true;
+		}
 
 		const cancelButtonText = options.cancelButtonText ? options.cancelButtonText : 'Cancel';
 		const okButtonText = options.okButtonText ? options.okButtonText : 'OK';
@@ -187,7 +197,9 @@ export class DateTimePicker extends DateTimePickerBase {
 			if (this.SUPPORT_TEXT_COLOR) {
 				nativePicker.setValueForKey(color.ios, 'textColor');
 			}
-			nativePicker.setValueForKey(false, 'highlightsToday');
+			if (nativePicker.preferredDatePickerStyle === 1) {
+				nativePicker.setValueForKey(false, 'highlightsToday');
+			}
 		}
 	}
 

--- a/packages/datetimepicker/package.json
+++ b/packages/datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nativescript/datetimepicker",
-	"version": "2.0.4",
+	"version": "2.0.4-patch.4",
 	"description": "A NativeScript plugin for picking date and time.",
 	"main": "index",
 	"typings": "index.d.ts",

--- a/packages/datetimepicker/ui/date-picker-field.common.ts
+++ b/packages/datetimepicker/ui/date-picker-field.common.ts
@@ -11,6 +11,7 @@ export class DatePickerFieldBase extends PickerFieldBase implements DatePickerFi
 	public minDate: Date;
 	public date: Date;
 	public dateFormat: string;
+	public firstWeekday: number;
 	public pickerDefaultDate: Date;
 	public iosPreferredDatePickerStyle: number | undefined;
 	public static datePickerOpenedEvent = 'datePickerOpened';
@@ -43,6 +44,10 @@ export class DatePickerFieldBase extends PickerFieldBase implements DatePickerFi
 		valueChanged: DatePickerFieldBase.dateFormatPropertyChanged,
 	});
 
+	public static firstWeekdayProperty = new Property<DatePickerFieldBase, number>({
+		name: 'firstWeekday',
+	});
+
 	public static pickerDefaultDateProperty = new Property<DatePickerFieldBase, Date>({
 		name: 'pickerDefaultDate',
 		defaultValue: getDateToday(),
@@ -63,6 +68,7 @@ export class DatePickerFieldBase extends PickerFieldBase implements DatePickerFi
 				locale: this.locale,
 				minDate: this.minDate,
 				maxDate: this.maxDate,
+				firstWeekday: this.firstWeekday,
 				iosPreferredDatePickerStyle: this.iosPreferredDatePickerStyle,
 				title: this.pickerTitle,
 				okButtonText: this.pickerOkText,

--- a/packages/datetimepicker/ui/date-picker-field.common.ts
+++ b/packages/datetimepicker/ui/date-picker-field.common.ts
@@ -1,131 +1,140 @@
-import { EventData, Property, CSSType } from "@nativescript/core";
-import { DateTimePicker, DateTimePickerStyle } from "..";
-import { DatePickerField as DatePickerFieldDefinition } from "./date-picker-field";
-import { LocalizationUtils } from "../utils/localization-utils";
-import { getDateToday, dateComparer } from "../utils";
-import { PickerFieldBase } from "./picker-field-base";
+import { EventData, Property, CSSType } from '@nativescript/core';
+import { DateTimePicker, DateTimePickerStyle } from '..';
+import { DatePickerField as DatePickerFieldDefinition } from './date-picker-field';
+import { LocalizationUtils } from '../utils/localization-utils';
+import { getDateToday, dateComparer } from '../utils';
+import { PickerFieldBase } from './picker-field-base';
 
-@CSSType("DatePickerField")
+@CSSType('DatePickerField')
 export class DatePickerFieldBase extends PickerFieldBase implements DatePickerFieldDefinition {
-    public maxDate: Date;
-    public minDate: Date;
-    public date: Date;
-    public dateFormat: string;
-    public pickerDefaultDate: Date;
-    public static datePickerOpenedEvent = "datePickerOpened";
-    public static datePickerClosedEvent = "datePickerClosed";
+	public maxDate: Date;
+	public minDate: Date;
+	public date: Date;
+	public dateFormat: string;
+	public pickerDefaultDate: Date;
+	public iosPreferredDatePickerStyle: number | undefined;
+	public static datePickerOpenedEvent = 'datePickerOpened';
+	public static datePickerClosedEvent = 'datePickerClosed';
 
-    private _nativeLocale: any;
-    private _nativeDateFormatter: any;
+	private _nativeLocale: any;
+	private _nativeDateFormatter: any;
 
-    public static dateProperty = new Property<DatePickerFieldBase, Date>({
-        name: "date",
-        equalityComparer: dateComparer,
-        valueConverter: dateValueConverter,
-        valueChanged: DatePickerFieldBase.datePropertyChanged
-    });
+	public static dateProperty = new Property<DatePickerFieldBase, Date>({
+		name: 'date',
+		equalityComparer: dateComparer,
+		valueConverter: dateValueConverter,
+		valueChanged: DatePickerFieldBase.datePropertyChanged,
+	});
 
-    public static maxDateProperty = new Property<DatePickerFieldBase, Date>({
-        name: "maxDate",
-        equalityComparer: dateComparer,
-        valueConverter: dateValueConverter,
-    });
+	public static maxDateProperty = new Property<DatePickerFieldBase, Date>({
+		name: 'maxDate',
+		equalityComparer: dateComparer,
+		valueConverter: dateValueConverter,
+	});
 
-    public static minDateProperty = new Property<DatePickerFieldBase, Date>({
-        name: "minDate",
-        equalityComparer: dateComparer,
-        valueConverter: dateValueConverter,
-    });
+	public static minDateProperty = new Property<DatePickerFieldBase, Date>({
+		name: 'minDate',
+		equalityComparer: dateComparer,
+		valueConverter: dateValueConverter,
+	});
 
-    public static dateFormatProperty = new Property<DatePickerFieldBase, string>({
-        name: "dateFormat",
-        valueChanged: DatePickerFieldBase.dateFormatPropertyChanged,
-    });
+	public static dateFormatProperty = new Property<DatePickerFieldBase, string>({
+		name: 'dateFormat',
+		valueChanged: DatePickerFieldBase.dateFormatPropertyChanged,
+	});
 
-    public static pickerDefaultDateProperty = new Property<DatePickerFieldBase, Date>({
-        name: "pickerDefaultDate",
-        defaultValue: getDateToday(),
-        equalityComparer: dateComparer,
-        valueConverter: dateValueConverter,
-    });
+	public static pickerDefaultDateProperty = new Property<DatePickerFieldBase, Date>({
+		name: 'pickerDefaultDate',
+		defaultValue: getDateToday(),
+		equalityComparer: dateComparer,
+		valueConverter: dateValueConverter,
+	});
 
-    public open(): void {
-        const style = DateTimePickerStyle.create(this);
-        DateTimePicker.pickDate({
-            context: this._context,
-            date: this.date ? this.date : this.pickerDefaultDate,
-            locale: this.locale,
-            minDate: this.minDate,
-            maxDate: this.maxDate,
-            title: this.pickerTitle,
-            okButtonText: this.pickerOkText,
-            cancelButtonText: this.pickerCancelText
-        }, style)
-        .then((result: Date) => {
-            if (result) {
-                this.date = result;
-            }
-            let args = <EventData>{
-                eventName: DatePickerFieldBase.datePickerClosedEvent,
-                object: this
-            };
-            this.notify(args);
-        })
-        .catch((err) => {
-            console.log('DatePickerField Error: ' + err);
-        });
-        let args = <EventData>{
-            eventName: DatePickerFieldBase.datePickerOpenedEvent,
-            object: this
-        };
-        this.notify(args);
-    }
+	public static iosPreferredDatePickerStyleProperty = new Property<DatePickerFieldBase, number>({
+		name: 'iosPreferredDatePickerStyle',
+	});
 
-    public updateText() {
-        if (!this._nativeDateFormatter) {
-            this._initRegionalSettings();
-        }
-        this.text = this.date ? this.getFormattedDate(this.date) : "";
-    }
+	public open(): void {
+		const style = DateTimePickerStyle.create(this);
+		DateTimePicker.pickDate(
+			{
+				context: this._context,
+				date: this.date ? this.date : this.pickerDefaultDate,
+				locale: this.locale,
+				minDate: this.minDate,
+				maxDate: this.maxDate,
+				iosPreferredDatePickerStyle: this.iosPreferredDatePickerStyle,
+				title: this.pickerTitle,
+				okButtonText: this.pickerOkText,
+				cancelButtonText: this.pickerCancelText,
+			},
+			style
+		)
+			.then((result: Date) => {
+				if (result) {
+					this.date = result;
+				}
+				let args = <EventData>{
+					eventName: DatePickerFieldBase.datePickerClosedEvent,
+					object: this,
+				};
+				this.notify(args);
+			})
+			.catch((err) => {
+				console.log('DatePickerField Error: ' + err);
+			});
+		let args = <EventData>{
+			eventName: DatePickerFieldBase.datePickerOpenedEvent,
+			object: this,
+		};
+		this.notify(args);
+	}
 
-    initNativeView() {
-        super.initNativeView();
-        this._updateRegionalSettings();
-    }
+	public updateText() {
+		if (!this._nativeDateFormatter) {
+			this._initRegionalSettings();
+		}
+		this.text = this.date ? this.getFormattedDate(this.date) : '';
+	}
 
-    private static datePropertyChanged(field: DatePickerFieldBase, oldValue: Date, newValue: Date) {
-        field.updateText();
-    }
+	initNativeView() {
+		super.initNativeView();
+		this._updateRegionalSettings();
+	}
 
-    private static dateFormatPropertyChanged(field: DatePickerFieldBase, oldValue: string, newValue: string) {
-        field.onDateFormatChanged(oldValue, newValue);
-    }
+	private static datePropertyChanged(field: DatePickerFieldBase, oldValue: Date, newValue: Date) {
+		field.updateText();
+	}
 
-    protected onDateFormatChanged(oldValue: string, newValue: string) {
-        this._updateRegionalSettings();
-    }
+	private static dateFormatPropertyChanged(field: DatePickerFieldBase, oldValue: string, newValue: string) {
+		field.onDateFormatChanged(oldValue, newValue);
+	}
 
-    protected onLocaleChanged(oldValue: string, newValue: string) {
-        this._updateRegionalSettings();
-    }
+	protected onDateFormatChanged(oldValue: string, newValue: string) {
+		this._updateRegionalSettings();
+	}
 
-    protected getFormattedDate(date: Date): string {
-        return LocalizationUtils.formatDateTime(this._nativeDateFormatter, date);
-    }
+	protected onLocaleChanged(oldValue: string, newValue: string) {
+		this._updateRegionalSettings();
+	}
 
-    private _initRegionalSettings() {
-        this._nativeLocale = LocalizationUtils.createNativeLocale(this.locale);
-        this._nativeDateFormatter = LocalizationUtils.createNativeDateFormatter(this.dateFormat, this._nativeLocale);
-    }
+	protected getFormattedDate(date: Date): string {
+		return LocalizationUtils.formatDateTime(this._nativeDateFormatter, date);
+	}
 
-    private _updateRegionalSettings() {
-        this._initRegionalSettings();
-        this.updateText();
-    }
+	private _initRegionalSettings() {
+		this._nativeLocale = LocalizationUtils.createNativeLocale(this.locale);
+		this._nativeDateFormatter = LocalizationUtils.createNativeDateFormatter(this.dateFormat, this._nativeLocale);
+	}
+
+	private _updateRegionalSettings() {
+		this._initRegionalSettings();
+		this.updateText();
+	}
 }
 
 export function dateValueConverter(v: any): Date {
-    return new Date(v);
+	return new Date(v);
 }
 
 DatePickerFieldBase.dateProperty.register(DatePickerFieldBase);

--- a/packages/datetimepicker/ui/date-picker-field.d.ts
+++ b/packages/datetimepicker/ui/date-picker-field.d.ts
@@ -45,6 +45,12 @@ export class DatePickerField extends TextField {
 	locale: string;
 
 	/**
+	 * Gets or sets the first day of week for iOS 14+ DatePicker in calendar mode
+	 * Defaults to 1 (sunday)
+	 */
+	firstWeekday: number;
+
+	/**
 	 * Gets or sets the hint text. Hint is the text that is displayed in the field when {@link date} is null.
 	 */
 	hint: string;
@@ -108,6 +114,11 @@ export class DatePickerField extends TextField {
 	 * Identifies the {@link locale} dependency property.
 	 */
 	static localeProperty: Property<DatePickerField, string>;
+
+	/**
+	 * Identifies the {@link firstWeekday} dependency property.
+	 */
+	static firstWeekdayProperty: Property<DatePickerField, string>;
 
 	/**
 	 * Identifies the {@link hint} dependency property.

--- a/packages/datetimepicker/ui/date-picker-field.d.ts
+++ b/packages/datetimepicker/ui/date-picker-field.d.ts
@@ -1,131 +1,141 @@
 /**
  * Contains the DatePickerField class.
  */
-import { TextField, Property } from "@nativescript/core";
+import { TextField, Property } from '@nativescript/core';
 
 /**
  * Represents a TextField that can be tapped to open a picker. The picker is a dialog with
  * date picking spinners along with OK/Cancel buttons.
  */
 export class DatePickerField extends TextField {
-    /**
-     * Gets or sets the selected date.
-     */
-    date: Date;
+	/**
+	 * Gets or sets the selected date.
+	 */
+	date: Date;
 
-    /**
-     * Gets or sets the max date.
-     */
-    maxDate: Date;
+	/**
+	 * Gets or sets the max date.
+	 */
+	maxDate: Date;
 
-    /**
-     * Gets or sets the min date.
-     */
-    minDate: Date;
+	/**
+	 * Gets or sets the min date.
+	 */
+	minDate: Date;
 
-    /**
-     * Gets or sets a format for displaying the date in the field.
-     * Default value is undefined, meaning that the format will be based on the current locale.
-     * Here are some examples with the way 1st of April, 2019 is displayed for each of the formats:
-     * MMM dd, yyyy - Apr 01, 2019
-     * d.M.yy - 1.4.19
-     * EEE, d MMMM yyyy - Mon, 1 April 2019
-     */
-    dateFormat: string;
+	/**
+	 * Gets or sets a format for displaying the date in the field.
+	 * Default value is undefined, meaning that the format will be based on the current locale.
+	 * Here are some examples with the way 1st of April, 2019 is displayed for each of the formats:
+	 * MMM dd, yyyy - Apr 01, 2019
+	 * d.M.yy - 1.4.19
+	 * EEE, d MMMM yyyy - Mon, 1 April 2019
+	 */
+	dateFormat: string;
 
-    /**
-     * Gets or sets a locale for displaying the date in the field, and also for the picker.
-     * Default value is undefined, meaning that the format will be based on the device's settings.
-     * In order to fixate the date to English, you can use English-based locales like: en_US, en_UK, etc.
-     * If you want to provide localization for your app, you can supply different locales, depending
-     * on the selected setting.
-     * Note that changing the locale will not affect the {@link pickerOkText}, {@link pickerCancelText}
-     * and {@link pickerTitle} or {@link hint} properties.
-     */
-    locale: string;
+	/**
+	 * Gets or sets a locale for displaying the date in the field, and also for the picker.
+	 * Default value is undefined, meaning that the format will be based on the device's settings.
+	 * In order to fixate the date to English, you can use English-based locales like: en_US, en_UK, etc.
+	 * If you want to provide localization for your app, you can supply different locales, depending
+	 * on the selected setting.
+	 * Note that changing the locale will not affect the {@link pickerOkText}, {@link pickerCancelText}
+	 * and {@link pickerTitle} or {@link hint} properties.
+	 */
+	locale: string;
 
-    /**
-     * Gets or sets the hint text. Hint is the text that is displayed in the field when {@link date} is null.
-     */
-    hint: string;
+	/**
+	 * Gets or sets the hint text. Hint is the text that is displayed in the field when {@link date} is null.
+	 */
+	hint: string;
 
-    /**
-     * Gets or sets the date that will be initially selected in the picker when {@link date} is null.
-     *
-     * @default today
-     */
-    pickerDefaultDate: Date;
+	/**
+	 * Gets or sets the date that will be initially selected in the picker when {@link date} is null.
+	 *
+	 * @default today
+	 */
+	pickerDefaultDate: Date;
 
-    /**
-     * Gets or sets the title. The title is the text that is displayed in the picker
-     * above the date selecting spinners.
-     */
-    pickerTitle: string;
+	/**
+	 * Gets or sets the title. The title is the text that is displayed in the picker
+	 * above the date selecting spinners.
+	 */
+	pickerTitle: string;
 
-    /**
-     * Gets or sets the text of the button in the picker that is used to confirm the selection.
-     * By default, on iOS the text will be OK, while on android the text will be
-     * determined by the current device's localization settings. Please note, that the value
-     * is not related with the value {@link locale} property.
-     */
-    pickerOkText: string;
+	/**
+	 * Gets or sets the text of the button in the picker that is used to confirm the selection.
+	 * By default, on iOS the text will be OK, while on android the text will be
+	 * determined by the current device's localization settings. Please note, that the value
+	 * is not related with the value {@link locale} property.
+	 */
+	pickerOkText: string;
 
-    /**
-     * Gets or sets the text of the button in the picker that is used to dismiss the picker,
-     * and cancel the current date selection.
-     * By default, on iOS the text will be Cancel, while on android the text will be
-     * determined by the current device's localization settings. Please note, that the value
-     * is not related with the value {@link locale} property.
-     */
-    pickerCancelText: string;
+	/**
+	 * Gets or sets the text of the button in the picker that is used to dismiss the picker,
+	 * and cancel the current date selection.
+	 * By default, on iOS the text will be Cancel, while on android the text will be
+	 * determined by the current device's localization settings. Please note, that the value
+	 * is not related with the value {@link locale} property.
+	 */
+	pickerCancelText: string;
 
-    /**
-     * Identifies the {@link date} dependency property.
-     */
-    static dateProperty: Property<DatePickerField, Date>;
+	/**
+	 * Gets of sets the UIDatePicker preferred style (starting from iOS 13.4).
+	 */
+	iosPreferredDatePickerStyle: number;
 
-    /**
-     * Identifies the {@link maxDate} dependency property.
-     */
-    static maxDateProperty: Property<DatePickerField, Date>;
+	/**
+	 * Identifies the {@link date} dependency property.
+	 */
+	static dateProperty: Property<DatePickerField, Date>;
 
-    /**
-     * Identifies the {@link minDate} dependency property.
-     */
-    static minDateProperty: Property<DatePickerField, Date>;
+	/**
+	 * Identifies the {@link maxDate} dependency property.
+	 */
+	static maxDateProperty: Property<DatePickerField, Date>;
 
-    /**
-     * Identifies the {@link dateFormat} dependency property.
-     */
-    static dateFormatProperty: Property<DatePickerField, string>;
+	/**
+	 * Identifies the {@link minDate} dependency property.
+	 */
+	static minDateProperty: Property<DatePickerField, Date>;
 
-    /**
-     * Identifies the {@link locale} dependency property.
-     */
-    static localeProperty: Property<DatePickerField, string>;
+	/**
+	 * Identifies the {@link dateFormat} dependency property.
+	 */
+	static dateFormatProperty: Property<DatePickerField, string>;
 
-    /**
-     * Identifies the {@link hint} dependency property.
-     */
-    static hintProperty: Property<DatePickerField, string>;
+	/**
+	 * Identifies the {@link locale} dependency property.
+	 */
+	static localeProperty: Property<DatePickerField, string>;
 
-    /**
-     * Identifies the {@link pickerDefaultDate} dependency property.
-     */
-    static pickerDefaultDateProperty: Property<DatePickerField, string>;
+	/**
+	 * Identifies the {@link hint} dependency property.
+	 */
+	static hintProperty: Property<DatePickerField, string>;
 
-    /**
-     * Identifies the {@link pickerTitle} dependency property.
-     */
-    static pickerTitleProperty: Property<DatePickerField, string>;
+	/**
+	 * Identifies the {@link pickerDefaultDate} dependency property.
+	 */
+	static pickerDefaultDateProperty: Property<DatePickerField, string>;
 
-    /**
-     * Identifies the {@link pickerOkText} dependency property.
-     */
-    static pickerOkTextProperty: Property<DatePickerField, string>;
+	/**
+	 * Identifies the {@link pickerTitle} dependency property.
+	 */
+	static pickerTitleProperty: Property<DatePickerField, string>;
 
-    /**
-     * Identifies the {@link pickerCancelText} dependency property.
-     */
-    static pickerCancelTextProperty: Property<DatePickerField, string>;
+	/**
+	 * Identifies the {@link pickerOkText} dependency property.
+	 */
+	static pickerOkTextProperty: Property<DatePickerField, string>;
+
+	/**
+	 * Identifies the {@link pickerCancelText} dependency property.
+	 */
+	static pickerCancelTextProperty: Property<DatePickerField, string>;
+
+	/**
+	 * Identifies the {@link iosPreferredDatePickerStyle} dependency property.
+	 */
+	static iosPreferredDatePickerStyle: Property<DatePickerField, number>;
 }

--- a/packages/datetimepicker/utils/localization-utils.android.ts
+++ b/packages/datetimepicker/utils/localization-utils.android.ts
@@ -1,70 +1,74 @@
-import { LocalizationUtilsBase } from "./localization-utils.common";
+import { LocalizationUtilsBase } from './localization-utils.common';
 
 export class LocalizationUtils extends LocalizationUtilsBase {
-    private static _localesCache: Map<string, any> = new Map<string, any>();
+	private static _localesCache: Map<string, any> = new Map<string, any>();
 
-    static createNativeLocale(locale?: string) {
-        if (LocalizationUtils._localesCache.has(locale)) {
-            return LocalizationUtils._localesCache.get(locale);
-        }
-        let result: java.util.Locale;
-        if (locale) {
-            locale = locale.replace(/_/g, "-");
-            let firstHypenIndex = locale.indexOf("-");
-            let lang = "";
-            let country = "";
-            if (firstHypenIndex > -1) {
-                lang = locale.substr(0, firstHypenIndex);
-                let nextHypenIndex = locale.substr(firstHypenIndex + 1).indexOf("-");
-                country = locale.substr(firstHypenIndex + 1, (nextHypenIndex > -1) ? nextHypenIndex : undefined);
-            } else {
-                lang = locale;
-            }
-            if (country !== "") {
-                result = new java.util.Locale(lang, country);
-            } else {
-                result = new java.util.Locale(lang);
-            }
-        } else {
-            result = java.util.Locale.getDefault();
-        }
-        LocalizationUtils._localesCache.set(locale, result);
-        return result;
-    }
+	static createNativeLocale(locale?: string) {
+		if (LocalizationUtils._localesCache.has(locale)) {
+			return LocalizationUtils._localesCache.get(locale);
+		}
+		let result: java.util.Locale;
+		if (locale) {
+			locale = locale.replace(/_/g, '-');
+			let firstHypenIndex = locale.indexOf('-');
+			let lang = '';
+			let country = '';
+			if (firstHypenIndex > -1) {
+				lang = locale.substr(0, firstHypenIndex);
+				let nextHypenIndex = locale.substr(firstHypenIndex + 1).indexOf('-');
+				country = locale.substr(firstHypenIndex + 1, nextHypenIndex > -1 ? nextHypenIndex : undefined);
+			} else {
+				lang = locale;
+			}
+			if (country !== '') {
+				result = new java.util.Locale(lang, country);
+			} else {
+				result = new java.util.Locale(lang);
+			}
+		} else {
+			result = java.util.Locale.getDefault();
+		}
+		LocalizationUtils._localesCache.set(locale, result);
+		return result;
+	}
 
-    static createDefaultTimeFormat(context: any): string {
-        const is24Hour = android.text.format.DateFormat.is24HourFormat(context);
-        const format = is24Hour ? LocalizationUtils.TIME_24H_FORMAT : LocalizationUtils.TIME_12H_FORMAT;
-        return format;
-    }
+	static createNativeCalendar(locale?: string, firstWeekday?: number) {
+		return null;
+	}
 
-    static createNativeDateFormatter(formatPattern: string, nativeLocale: any): any {
-        if (!formatPattern) {
-            return java.text.DateFormat.getDateInstance(java.text.DateFormat.DEFAULT, nativeLocale);
-        }
-        let nativeDateFormat = new java.text.SimpleDateFormat(formatPattern, nativeLocale);
-        return nativeDateFormat;
-    }
+	static createDefaultTimeFormat(context: any): string {
+		const is24Hour = android.text.format.DateFormat.is24HourFormat(context);
+		const format = is24Hour ? LocalizationUtils.TIME_24H_FORMAT : LocalizationUtils.TIME_12H_FORMAT;
+		return format;
+	}
 
-    static createNativeTimeFormatter(formatPattern: string, nativeLocale: any): any {
-        if (!formatPattern) {
-            return java.text.DateFormat.getTimeInstance(java.text.DateFormat.SHORT, nativeLocale);
-        }
-        let nativeDateFormat = new java.text.SimpleDateFormat(formatPattern, nativeLocale);
-        return nativeDateFormat;
-    }
+	static createNativeDateFormatter(formatPattern: string, nativeLocale: any): any {
+		if (!formatPattern) {
+			return java.text.DateFormat.getDateInstance(java.text.DateFormat.DEFAULT, nativeLocale);
+		}
+		let nativeDateFormat = new java.text.SimpleDateFormat(formatPattern, nativeLocale);
+		return nativeDateFormat;
+	}
 
-    static formatDateTime(formatter: any, dateTime: Date): string {
-        let nativeDate = new java.util.Date(dateTime.getTime());
-        let result = formatter.format(nativeDate);
-        return result;
-    }
+	static createNativeTimeFormatter(formatPattern: string, nativeLocale: any): any {
+		if (!formatPattern) {
+			return java.text.DateFormat.getTimeInstance(java.text.DateFormat.SHORT, nativeLocale);
+		}
+		let nativeDateFormat = new java.text.SimpleDateFormat(formatPattern, nativeLocale);
+		return nativeDateFormat;
+	}
 
-    static is24Hours(formatter: any): boolean {
-        const formatPattern = formatter.toPattern();
-        if (formatPattern.indexOf('H') < 0) {
-            return false;
-        }
-        return true;
-    }
+	static formatDateTime(formatter: any, dateTime: Date): string {
+		let nativeDate = new java.util.Date(dateTime.getTime());
+		let result = formatter.format(nativeDate);
+		return result;
+	}
+
+	static is24Hours(formatter: any): boolean {
+		const formatPattern = formatter.toPattern();
+		if (formatPattern.indexOf('H') < 0) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/packages/datetimepicker/utils/localization-utils.d.ts
+++ b/packages/datetimepicker/utils/localization-utils.d.ts
@@ -1,9 +1,10 @@
 export declare class LocalizationUtils {
-    private static _localesCache;
-    static createNativeLocale(locale?: string): any;
-    static createDefaultTimeFormat(context: any): string;
-    static createNativeDateFormatter(formatPattern: string, nativeLocale: any): any;
-    static createNativeTimeFormatter(formatPattern: string, nativeLocale: any): any;
-    static formatDateTime(formatter: any, dateTime: Date): string;
-    static is24Hours(formatter: any): boolean;
+	private static _localesCache;
+	static createNativeLocale(locale?: string): any;
+	static createNativeCalendar(locale?: string, firstWeekday?: number): any;
+	static createDefaultTimeFormat(context: any): string;
+	static createNativeDateFormatter(formatPattern: string, nativeLocale: any): any;
+	static createNativeTimeFormatter(formatPattern: string, nativeLocale: any): any;
+	static formatDateTime(formatter: any, dateTime: Date): string;
+	static is24Hours(formatter: any): boolean;
 }

--- a/packages/datetimepicker/utils/localization-utils.ios.ts
+++ b/packages/datetimepicker/utils/localization-utils.ios.ts
@@ -1,55 +1,65 @@
-import { LocalizationUtilsBase } from "./localization-utils.common";
+import { LocalizationUtilsBase } from './localization-utils.common';
 
 export class LocalizationUtils extends LocalizationUtilsBase {
-    private static _localesCache: Map<string, any> = new Map<string, any>();
+	private static _localesCache: Map<string, any> = new Map<string, any>();
 
-    static createNativeLocale(localeIdentifier: string): any {
-        if (LocalizationUtils._localesCache.has(localeIdentifier)) {
-            return LocalizationUtils._localesCache.get(localeIdentifier);
-        }
-        let result: NSLocale;
-        if (localeIdentifier) {
-            result = NSLocale.alloc().initWithLocaleIdentifier(localeIdentifier);
-        } else {
-            result = NSLocale.currentLocale;
-        }
-        LocalizationUtils._localesCache.set(localeIdentifier, result);
-        return result;
-    }
+	static createNativeLocale(localeIdentifier: string): any {
+		if (LocalizationUtils._localesCache.has(localeIdentifier)) {
+			return LocalizationUtils._localesCache.get(localeIdentifier);
+		}
+		let result: NSLocale;
+		if (localeIdentifier) {
+			result = NSLocale.alloc().initWithLocaleIdentifier(localeIdentifier);
+		} else {
+			result = NSLocale.currentLocale;
+		}
+		LocalizationUtils._localesCache.set(localeIdentifier, result);
+		return result;
+	}
 
-    static createNativeDateFormatter(formatPattern: string, nativeLocale: any): any {
-        let dateFormatter = NSDateFormatter.alloc().init();
-        dateFormatter.locale = nativeLocale;
-        if (!formatPattern) {
-            dateFormatter.dateStyle = NSDateFormatterStyle.MediumStyle;
-            dateFormatter.timeStyle = NSDateFormatterStyle.NoStyle;
-        } else {
-            dateFormatter.dateFormat = formatPattern;
-        }
-        return dateFormatter;
-    }
+	static createNativeCalendar(localeIdentifier: string, firstWeekday?: number): any {
+		const locale = LocalizationUtils.createNativeLocale(localeIdentifier);
+		const calendar = NSCalendar.alloc().initWithCalendarIdentifier(locale.calendarIdentifier);
+		calendar.locale = locale;
+		if (firstWeekday !== undefined) {
+			calendar.firstWeekday = firstWeekday;
+		}
+		return calendar;
+	}
 
-    static createNativeTimeFormatter(formatPattern: string, nativeLocale: any): any {
-        let dateFormatter = NSDateFormatter.alloc().init();
-        dateFormatter.locale = nativeLocale;
-        if (!formatPattern) {
-            dateFormatter.dateStyle = NSDateFormatterStyle.NoStyle;
-            dateFormatter.timeStyle = NSDateFormatterStyle.ShortStyle;
-        } else {
-            dateFormatter.dateFormat = formatPattern;
-        }
-        return dateFormatter;
-    }
+	static createNativeDateFormatter(formatPattern: string, nativeLocale: any): any {
+		let dateFormatter = NSDateFormatter.alloc().init();
+		dateFormatter.locale = nativeLocale;
+		if (!formatPattern) {
+			dateFormatter.dateStyle = NSDateFormatterStyle.MediumStyle;
+			dateFormatter.timeStyle = NSDateFormatterStyle.NoStyle;
+		} else {
+			dateFormatter.dateFormat = formatPattern;
+		}
+		return dateFormatter;
+	}
 
-    static formatDateTime(formatter: any, dateTime: Date): string {
-        return formatter.stringFromDate(dateTime);
-    }
+	static createNativeTimeFormatter(formatPattern: string, nativeLocale: any): any {
+		let dateFormatter = NSDateFormatter.alloc().init();
+		dateFormatter.locale = nativeLocale;
+		if (!formatPattern) {
+			dateFormatter.dateStyle = NSDateFormatterStyle.NoStyle;
+			dateFormatter.timeStyle = NSDateFormatterStyle.ShortStyle;
+		} else {
+			dateFormatter.dateFormat = formatPattern;
+		}
+		return dateFormatter;
+	}
 
-    static is24Hours(formatter: any): boolean {
-        const formatPattern = formatter.dateFormat;
-        if (formatPattern.indexOf('H') < 0) {
-            return false;
-        }
-        return true;
-    }
+	static formatDateTime(formatter: any, dateTime: Date): string {
+		return formatter.stringFromDate(dateTime);
+	}
+
+	static is24Hours(formatter: any): boolean {
+		const formatPattern = formatter.dateFormat;
+		if (formatPattern.indexOf('H') < 0) {
+			return false;
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
Added two new options in the iOS datePickerField :
- defaults to inline calendar view on iOS 14
- can be set to default spinner with iosPreferredDateStyle
- added new property firstWeekday to set the correct week view on the calendar
