### PR TITLE
fix(ios) [datetime-picker]: _getLabelContainer never resolved due to type error

### DIFF
--- a/packages/datetimepicker/index.ios.ts
+++ b/packages/datetimepicker/index.ios.ts
@@ -245,7 +245,7 @@ export class DateTimePicker extends DateTimePickerBase {
 	}
 
 	private static _getLabelContainer(uiView: UIView) {
-		if (uiView.superview.class() === UIView.class()) {
+		if (uiView && uiView.superview instanceof UIView) {
 			return uiView.superview;
 		}
 		return DateTimePicker._getLabelContainer(uiView.superview);


### PR DESCRIPTION
```
TypeError: uiView.superview.class is not a function. (In 'uiView.superview.class()', 'uiView.superview.class' is an instance of UIView)
```

Tested and fixed. Thank you