### PR TITLE
fix:(google-pay) Add the received token to the response in it's entirety

### DIFF
--- a/packages/google-pay/README.md
+++ b/packages/google-pay/README.md
@@ -541,6 +541,11 @@ interface PaymentSuccessEventData extends EventData {
 					 * A JSON object serialized as a string that contains the encryptedMessage, ephemeralPublicKey, and tag. It's serialized to simplify the signature verification process.
 					 */
 					signedMessage: string;
+
+					/**
+					 * JSON object string that contains a chargeable token issued by your gateway
+					 */
+					rawToken: string;
 				};
 			};
 		};

--- a/packages/google-pay/index.android.ts
+++ b/packages/google-pay/index.android.ts
@@ -260,12 +260,22 @@ export class GooglePayBtn extends View {
 					const tokenType = tokenizationData.getString('type');
 					// https://developers.google.com/pay/api/web/guides/resources/payment-data-cryptography#payment-method-token-structure
 					const token = tokenizationData.getString('token');
-					// need it as JSONObject to grab the values
-					const tokenAsObject = new JSONObject(token);
 
-					const protocolVersion = tokenAsObject.getString('protocolVersion');
-					const signature = tokenAsObject.getString('signature');
-					const signedMessage = tokenAsObject.getString('signedMessage');
+					let protocolVersion: string;
+					let signature: string;
+					let signedMessage: string;
+
+					try {
+						// need it as JSONObject to grab the values
+						const tokenAsObject = new JSONObject(token);
+
+						protocolVersion = tokenAsObject.getString('protocolVersion');
+						signature = tokenAsObject.getString('signature');
+						signedMessage = tokenAsObject.getString('signedMessage');
+					} catch (error) {
+						// May not be able to parse the token OK if not
+						console.log('Unable to parse token:', error);
+					}
 
 					// https://developers.google.com/pay/api/web/reference/response-objects
 					this.notify(({
@@ -284,6 +294,7 @@ export class GooglePayBtn extends View {
 										protocolVersion,
 										signature,
 										signedMessage,
+										rawToken: token,
 									},
 								},
 							},

--- a/packages/google-pay/index.d.ts
+++ b/packages/google-pay/index.d.ts
@@ -307,6 +307,11 @@ export interface PaymentSuccessEventData extends EventData {
 					 * A JSON object serialized as a string that contains the encryptedMessage, ephemeralPublicKey, and tag. It's serialized to simplify the signature verification process.
 					 */
 					signedMessage: string;
+
+					/**
+					 * JSON object string that contains a chargeable token issued by your gateway
+					 */
+					rawToken: string;
 				};
 			};
 		};

--- a/packages/google-pay/interfaces.ts
+++ b/packages/google-pay/interfaces.ts
@@ -280,6 +280,11 @@ export interface PaymentSuccessEventData extends EventData {
 					 * A JSON object serialized as a string that contains the encryptedMessage, ephemeralPublicKey, and tag. It's serialized to simplify the signature verification process.
 					 */
 					signedMessage: string;
+
+					/**
+					 * JSON object string that contains a chargeable token issued by your gateway
+					 */
+					rawToken: string;
 				};
 			};
 		};


### PR DESCRIPTION
To address Ticket #120 where full token is required in the case of  token type PAYMENT_GATEWAY , and the token may not follow the spec for https://developers.google.com/pay/api/web/guides/resources/payment-data-cryptography#payment-method-token-structure 