### PR TITLE
Fixed time picker display and added minuteInterval property for iOS

### DIFF
--- a/packages/datetimepicker/common.ts
+++ b/packages/datetimepicker/common.ts
@@ -28,6 +28,7 @@ export interface TimePickerOptions extends PickerOptions {
 	time?: Date;
 	is24Hours?: boolean;
 	iosPreferredDatePickerStyle?: number;
+	timeInterval?: number;
 }
 
 export interface PickerOptions {

--- a/packages/datetimepicker/index.d.ts
+++ b/packages/datetimepicker/index.d.ts
@@ -62,6 +62,11 @@ export interface TimePickerOptions extends PickerOptions {
 	 * This value will be used only on Android to determine whether the picker will be in 12 or 24 hour format.
 	 */
 	is24Hours?: boolean;
+
+	/**
+	 * This value will be used on iOS for determine the minute interval of the picker
+	 */
+	timeInterval?: number;
 }
 
 /**

--- a/packages/datetimepicker/index.ios.ts
+++ b/packages/datetimepicker/index.ios.ts
@@ -10,6 +10,7 @@ export class DateTimePicker extends DateTimePickerBase {
 	private static readonly SUPPORT_DATE_PICKER_STYLE = parseFloat(Device.osVersion) >= 14.0;
 	private static readonly SUPPORT_TEXT_COLOR = parseFloat(Device.osVersion) < 14.0;
 	private static readonly DEFAULT_DATE_PICKER_STYLE = parseFloat(Device.osVersion) >= 14.0 ? 3 : 1;
+	private static readonly DEFAULT_TIME_PICKER_STYLE = 1;
 
 	public static PICKER_DEFAULT_MESSAGE_HEIGHT = parseFloat(Device.osVersion) >= 14.0 ? 300 : 192;
 	public static PICKER_WIDTH_INSETS = 16;
@@ -67,8 +68,11 @@ export class DateTimePicker extends DateTimePickerBase {
 	static _createNativeTimePicker(options: TimePickerOptions): UIDatePicker {
 		const pickerView = UIDatePicker.alloc().initWithFrame(CGRectZero);
 		pickerView.datePickerMode = UIDatePickerMode.Time;
+		if (options.timeInterval) {
+			pickerView.minuteInterval = options.timeInterval;
+		}
 		if (this.SUPPORT_DATE_PICKER_STYLE) {
-			pickerView.preferredDatePickerStyle = options.iosPreferredDatePickerStyle !== undefined ? options.iosPreferredDatePickerStyle : this.DEFAULT_DATE_PICKER_STYLE;
+			pickerView.preferredDatePickerStyle = options.iosPreferredDatePickerStyle !== undefined ? options.iosPreferredDatePickerStyle : this.DEFAULT_TIME_PICKER_STYLE;
 		}
 		const time = options.time ? options.time : getDateNow();
 		pickerView.date = time;

--- a/packages/datetimepicker/ui/time-picker-field.common.ts
+++ b/packages/datetimepicker/ui/time-picker-field.common.ts
@@ -1,159 +1,176 @@
-import { Property, CSSType, EventData } from "@nativescript/core";
-import { DateTimePicker, DateTimePickerStyle } from "..";
-import { TimePickerField as TimePickerFieldDefinition } from "./time-picker-field";
-import { LocalizationUtils } from "../utils/localization-utils";
-import { getDateNow, dateComparer } from "../utils/date-utils";
-import { PickerFieldBase } from "./picker-field-base";
+import { Property, CSSType, EventData } from '@nativescript/core';
+import { DateTimePicker, DateTimePickerStyle } from '..';
+import { TimePickerField as TimePickerFieldDefinition } from './time-picker-field';
+import { LocalizationUtils } from '../utils/localization-utils';
+import { getDateNow, dateComparer } from '../utils/date-utils';
+import { PickerFieldBase } from './picker-field-base';
 
-@CSSType("TimePickerField")
+@CSSType('TimePickerField')
 export class TimePickerFieldBase extends PickerFieldBase implements TimePickerFieldDefinition {
-    public time: Date;
-    public timeFormat: string;
-    public pickerDefaultTime: Date;
-    public static timePickerOpenedEvent = "timePickerOpened";
-    public static timePickerClosedEvent = "timePickerClosed";
+	public time: Date;
+	public timeFormat: string;
+	public timeInterval: number;
+	public pickerDefaultTime: Date;
+	public static timePickerOpenedEvent = 'timePickerOpened';
+	public static timePickerClosedEvent = 'timePickerClosed';
 
-    private _nativeLocale: any;
-    private _nativeTimeFormatter: any;
+	private _nativeLocale: any;
+	private _nativeTimeFormatter: any;
 
-    public static timeProperty = new Property<TimePickerFieldBase, Date>({
-        name: "time",
-        equalityComparer: dateComparer,
-        valueConverter: timeValueConverter,
-        valueChanged: TimePickerFieldBase.timePropertyChanged
-    });
+	public static timeProperty = new Property<TimePickerFieldBase, Date>({
+		name: 'time',
+		equalityComparer: dateComparer,
+		valueConverter: timeValueConverter,
+		valueChanged: TimePickerFieldBase.timePropertyChanged,
+	});
 
-    public static timeFormatProperty = new Property<TimePickerFieldBase, string>({
-        name: "timeFormat",
-        valueChanged: TimePickerFieldBase.timeFormatPropertyChanged
-    });
+	public static timeFormatProperty = new Property<TimePickerFieldBase, string>({
+		name: 'timeFormat',
+		valueChanged: TimePickerFieldBase.timeFormatPropertyChanged,
+	});
 
-    public static pickerDefaultTimeProperty = new Property<TimePickerFieldBase, Date>({
-        name: "pickerDefaultTime",
-        defaultValue: getDateNow(),
-        equalityComparer: dateComparer,
-        valueConverter: timeValueConverter
-    });
+	public static pickerDefaultTimeProperty = new Property<TimePickerFieldBase, Date>({
+		name: 'pickerDefaultTime',
+		defaultValue: getDateNow(),
+		equalityComparer: dateComparer,
+		valueConverter: timeValueConverter,
+	});
 
-    public open(): void {
-        const style = DateTimePickerStyle.create(this);
-        DateTimePicker.pickTime({
-            context: this._context,
-            time: this.time ? this.time : this.pickerDefaultTime,
-            locale: this.locale,
-            title: this.pickerTitle,
-            okButtonText: this.pickerOkText,
-            cancelButtonText: this.pickerCancelText,
-            is24Hours: this.is24Hours(this._nativeTimeFormatter)
-        }, style)
-            .then((result: Date) => {
-                if (result) {
-                    this.time = result;
-                }
-                let args = <EventData>{
-                    eventName: TimePickerFieldBase.timePickerClosedEvent,
-                    object: this
-                };
-                this.notify(args);
-            })
-            .catch((err) => {
-                console.log('TimePickerField Error: ' + err);
-            });
-        let args = <EventData>{
-            eventName: TimePickerFieldBase.timePickerOpenedEvent,
-            object: this
-        };
-        this.notify(args);
-    }
+	public static timeIntervalProperty = new Property<TimePickerFieldBase, number>({
+		name: 'timeInterval',
+		valueChanged: TimePickerFieldBase.timeIntervalPropertyChanged,
+	});
 
-    public updateText() {
-        if (!this._nativeTimeFormatter) {
-            this._initRegionalSettings();
-        }
-        this.text = this.time ? this.getFormattedTime(this.time) : "";
-    }
+	public open(): void {
+		const style = DateTimePickerStyle.create(this);
+		DateTimePicker.pickTime(
+			{
+				context: this._context,
+				time: this.time ? this.time : this.pickerDefaultTime,
+				locale: this.locale,
+				title: this.pickerTitle,
+				okButtonText: this.pickerOkText,
+				cancelButtonText: this.pickerCancelText,
+				is24Hours: this.is24Hours(this._nativeTimeFormatter),
+				timeInterval: this.timeInterval,
+			},
+			style
+		)
+			.then((result: Date) => {
+				if (result) {
+					this.time = result;
+				}
+				let args = <EventData>{
+					eventName: TimePickerFieldBase.timePickerClosedEvent,
+					object: this,
+				};
+				this.notify(args);
+			})
+			.catch((err) => {
+				console.log('TimePickerField Error: ' + err);
+			});
+		let args = <EventData>{
+			eventName: TimePickerFieldBase.timePickerOpenedEvent,
+			object: this,
+		};
+		this.notify(args);
+	}
 
-    initNativeView() {
-        super.initNativeView();
-        this._updateRegionalSettings();
-    }
+	public updateText() {
+		if (!this._nativeTimeFormatter) {
+			this._initRegionalSettings();
+		}
+		this.text = this.time ? this.getFormattedTime(this.time) : '';
+	}
 
-    private static timePropertyChanged(field: TimePickerFieldBase, oldValue: Date, newValue: Date) {
-        field.updateText();
-    }
+	initNativeView() {
+		super.initNativeView();
+		this._updateRegionalSettings();
+	}
 
-    private static timeFormatPropertyChanged(field: TimePickerFieldBase, oldValue: string, newValue: string) {
-        field.onTimeFormatChanged(oldValue, newValue);
-    }
+	private static timePropertyChanged(field: TimePickerFieldBase, oldValue: Date, newValue: Date) {
+		field.updateText();
+	}
 
-    protected onTimeFormatChanged(oldValue: string, newValue: string) {
-        this._updateRegionalSettings();
-    }
+	private static timeFormatPropertyChanged(field: TimePickerFieldBase, oldValue: string, newValue: string) {
+		field.onTimeFormatChanged(oldValue, newValue);
+	}
 
-    protected onLocaleChanged(oldValue: string, newValue: string) {
-        this._updateRegionalSettings();
-    }
+	private static timeIntervalPropertyChanged(field: TimePickerFieldBase, oldValue: number, newValue: number) {
+		field.onTimeIntervalChanged(oldValue, newValue);
+	}
 
-    protected _updateRegionalSettings() {
-        this._initRegionalSettings();
-        this.updateText();
-    }
+	protected onTimeFormatChanged(oldValue: string, newValue: string) {
+		this._updateRegionalSettings();
+	}
 
-    protected getFormattedTime(time: Date): string {
-        return LocalizationUtils.formatDateTime(this._nativeTimeFormatter, time);
-    }
+	protected onTimeIntervalChanged(oldValue: number, newValue: number) {}
 
-    private _initRegionalSettings() {
-        this._nativeLocale = LocalizationUtils.createNativeLocale(this.locale);
-        this._nativeTimeFormatter = LocalizationUtils.createNativeTimeFormatter(this.timeFormat, this._nativeLocale);
-    }
+	protected onLocaleChanged(oldValue: string, newValue: string) {
+		this._updateRegionalSettings();
+	}
 
-    private is24Hours(formatter): boolean {
-        return LocalizationUtils.is24Hours(formatter);
-    }
+	protected _updateRegionalSettings() {
+		this._initRegionalSettings();
+		this.updateText();
+	}
+
+	protected getFormattedTime(time: Date): string {
+		return LocalizationUtils.formatDateTime(this._nativeTimeFormatter, time);
+	}
+
+	private _initRegionalSettings() {
+		this._nativeLocale = LocalizationUtils.createNativeLocale(this.locale);
+		this._nativeTimeFormatter = LocalizationUtils.createNativeTimeFormatter(this.timeFormat, this._nativeLocale);
+	}
+
+	private is24Hours(formatter): boolean {
+		return LocalizationUtils.is24Hours(formatter);
+	}
 }
 
 // Creates a date for today with the time represented in the timeString in ISO 8601 formats
 // as specified here: https://en.wikipedia.org/wiki/ISO_8601#Times:
 // 1)hh:mm:ss.sss --- 2)hhmmss.sss --- 3)hh:mm:ss --- 4)hhmmss --- 5)hh:mm --- 6)hhmm --- 7)hh
 export function timeValueConverter(timeString: string) {
-    let date = new Date();
-    date.setMilliseconds(0);
-    date.setSeconds(0);
-    if (timeString.length < 2 || isNaN(+timeString.substring(0, 2))) {
-        // The string can't be parsed, so default to time now
-        return date;
-    }
-    const hours = +timeString.substring(0, 2);
-    date.setHours(hours);
-    date.setMinutes(0);
-    let timeRemainder = timeString.substring(2);
-    timeRemainder = timeRemainder.startsWith(':') ? timeRemainder.substring(1) : timeRemainder;
-    if (timeRemainder.length < 2 || isNaN(+timeRemainder.substring(0, 2))) {
-        // Successfully parsed a date is in the 7)hh format
-        return date;
-    }
-    const minutes = +timeRemainder.substring(0, 2);
-    date.setMinutes(minutes);
-    timeRemainder = timeRemainder.substring(2);
-    timeRemainder = timeRemainder.startsWith(':') ? timeRemainder.substring(1) : timeRemainder;
-    if (timeRemainder.length < 2 || isNaN(+timeRemainder.substring(0, 2))) {
-        // Successfully parsed a date is in the 5)hh:mm or 6)hhmm format
-        return date;
-    }
-    const seconds = +timeRemainder.substring(0, 2);
-    date.setSeconds(seconds);
-    timeRemainder = timeRemainder.substring(2);
-    timeRemainder = timeRemainder.startsWith('.') ? timeRemainder.substring(1) : timeRemainder;
-    if (timeRemainder.length < 3 || isNaN(+timeRemainder.substring(0, 3))) {
-        // Successfully parsed a date is in the 3)hh:mm:ss or 4)hhmmss format
-        return date;
-    }
-    const milliseconds = +timeRemainder.substring(0, 3);
-    date.setMilliseconds(milliseconds);
-    // Successfully parsed a date in the 1)hh:mm:ss.sss or 2)hhmmss.sss format
-    return date;
+	let date = new Date();
+	date.setMilliseconds(0);
+	date.setSeconds(0);
+	if (timeString.length < 2 || isNaN(+timeString.substring(0, 2))) {
+		// The string can't be parsed, so default to time now
+		return date;
+	}
+	const hours = +timeString.substring(0, 2);
+	date.setHours(hours);
+	date.setMinutes(0);
+	let timeRemainder = timeString.substring(2);
+	timeRemainder = timeRemainder.startsWith(':') ? timeRemainder.substring(1) : timeRemainder;
+	if (timeRemainder.length < 2 || isNaN(+timeRemainder.substring(0, 2))) {
+		// Successfully parsed a date is in the 7)hh format
+		return date;
+	}
+	const minutes = +timeRemainder.substring(0, 2);
+	date.setMinutes(minutes);
+	timeRemainder = timeRemainder.substring(2);
+	timeRemainder = timeRemainder.startsWith(':') ? timeRemainder.substring(1) : timeRemainder;
+	if (timeRemainder.length < 2 || isNaN(+timeRemainder.substring(0, 2))) {
+		// Successfully parsed a date is in the 5)hh:mm or 6)hhmm format
+		return date;
+	}
+	const seconds = +timeRemainder.substring(0, 2);
+	date.setSeconds(seconds);
+	timeRemainder = timeRemainder.substring(2);
+	timeRemainder = timeRemainder.startsWith('.') ? timeRemainder.substring(1) : timeRemainder;
+	if (timeRemainder.length < 3 || isNaN(+timeRemainder.substring(0, 3))) {
+		// Successfully parsed a date is in the 3)hh:mm:ss or 4)hhmmss format
+		return date;
+	}
+	const milliseconds = +timeRemainder.substring(0, 3);
+	date.setMilliseconds(milliseconds);
+	// Successfully parsed a date in the 1)hh:mm:ss.sss or 2)hhmmss.sss format
+	return date;
 }
 TimePickerFieldBase.timeProperty.register(TimePickerFieldBase);
 TimePickerFieldBase.timeFormatProperty.register(TimePickerFieldBase);
+TimePickerFieldBase.timeIntervalProperty.register(TimePickerFieldBase);
 TimePickerFieldBase.pickerDefaultTimeProperty.register(TimePickerFieldBase);

--- a/packages/datetimepicker/ui/time-picker-field.d.ts
+++ b/packages/datetimepicker/ui/time-picker-field.d.ts
@@ -1,111 +1,121 @@
 /**
  * Contains the TimePickerField class.
  */
-import { TextField, Property } from "@nativescript/core";
+import { TextField, Property } from '@nativescript/core';
 
 /**
  * Represents a TextField that can be tapped to open a picker. The picker is a dialog with
  * time picking spinners along with OK/Cancel buttons.
  */
 export class TimePickerField extends TextField {
-    /**
-     * Gets or sets the selected time.
-     */
-    time: Date;
+	/**
+	 * Gets or sets the selected time.
+	 */
+	time: Date;
 
-    /**
-     * Gets or sets a format for displaying the date in the field.
-     * Default value is undefined, meaning that the format will be based on the current locale.
-     * Here are some examples with the way 1st of April, 2019 is displayed for each of the formats:
-     * MMM dd, yyyy - Apr 01, 2019
-     * d.M.yy - 1.4.19
-     * EEE, d MMMM yyyy - Mon, 1 April 2019
-     */
-    timeFormat: string;
+	/**
+	 * Gets or sets a format for displaying the date in the field.
+	 * Default value is undefined, meaning that the format will be based on the current locale.
+	 * Here are some examples with the way 1st of April, 2019 is displayed for each of the formats:
+	 * MMM dd, yyyy - Apr 01, 2019
+	 * d.M.yy - 1.4.19
+	 * EEE, d MMMM yyyy - Mon, 1 April 2019
+	 */
+	timeFormat: string;
 
-    /**
-     * Gets or sets a locale for displaying the date in the field, and also for the picker.
-     * Default value is undefined, meaning that the format will be based on the device's settings.
-     * In order to fixate the date to English, you can use English-based locales like: en_US, en_UK, etc.
-     * If you want to provide localization for your app, you can supply different locales, depending
-     * on the selected setting.
-     * Note that changing the locale will not affect the {@link pickerOkText}, {@link pickerCancelText}
-     * and {@link pickerTitle} or {@link hint} properties.
-     */
-    locale: string;
+	/**
+	 * Gets or sets a locale for displaying the date in the field, and also for the picker.
+	 * Default value is undefined, meaning that the format will be based on the device's settings.
+	 * In order to fixate the date to English, you can use English-based locales like: en_US, en_UK, etc.
+	 * If you want to provide localization for your app, you can supply different locales, depending
+	 * on the selected setting.
+	 * Note that changing the locale will not affect the {@link pickerOkText}, {@link pickerCancelText}
+	 * and {@link pickerTitle} or {@link hint} properties.
+	 */
+	locale: string;
 
-    /**
-     * Gets or sets the hint text. Hint is the text that is displayed in the field when {@link time} is null.
-     */
-    hint: string;
+	/**
+	 * Gets or sets the hint text. Hint is the text that is displayed in the field when {@link time} is null.
+	 */
+	hint: string;
 
-    /**
-     * Gets or sets the time that will be initially selected in the picker when {@link time} is null.
-     *
-     * @default now
-     */
-    pickerDefaultTime: Date;
+	/**
+	 * Gets or sets the time that will be initially selected in the picker when {@link time} is null.
+	 *
+	 * @default now
+	 */
+	pickerDefaultTime: Date;
 
-    /**
-     * Gets or sets the title. The title is the text that is displayed in the picker
-     * above the date selecting spinners.
-     */
-    pickerTitle: string;
+	/**
+	 * Gets or sets the time interval for the time picker
+	 */
+	timeInterval: number;
 
-    /**
-     * Gets or sets the text of the button in the picker that is used to confirm the selection.
-     * By default, on iOS the text will be OK, while on android the text will be
-     * determined by the current device's localization settings. Please note, that the value
-     * is not related with the value {@link locale} property.
-     */
-    pickerOkText: string;
+	/**
+	 * Gets or sets the title. The title is the text that is displayed in the picker
+	 * above the date selecting spinners.
+	 */
+	pickerTitle: string;
 
-    /**
-     * Gets or sets the text of the button in the picker that is used to dismiss the picker,
-     * and cancel the current date selection.
-     * By default, on iOS the text will be Cancel, while on android the text will be
-     * determined by the current device's localization settings. Please note, that the value
-     * is not related with the value {@link locale} property.
-     */
-    pickerCancelText: string;
+	/**
+	 * Gets or sets the text of the button in the picker that is used to confirm the selection.
+	 * By default, on iOS the text will be OK, while on android the text will be
+	 * determined by the current device's localization settings. Please note, that the value
+	 * is not related with the value {@link locale} property.
+	 */
+	pickerOkText: string;
 
-    /**
-     * Identifies the {@link time} dependency property.
-     */
-    static timeProperty: Property<TimePickerField, Date>;
+	/**
+	 * Gets or sets the text of the button in the picker that is used to dismiss the picker,
+	 * and cancel the current date selection.
+	 * By default, on iOS the text will be Cancel, while on android the text will be
+	 * determined by the current device's localization settings. Please note, that the value
+	 * is not related with the value {@link locale} property.
+	 */
+	pickerCancelText: string;
 
-    /**
-     * Identifies the {@link timeFormat} dependency property.
-     */
-    static timeFormatProperty: Property<TimePickerField, string>;
+	/**
+	 * Identifies the {@link time} dependency property.
+	 */
+	static timeProperty: Property<TimePickerField, Date>;
 
-    /**
-     * Identifies the {@link locale} dependency property.
-     */
-    static localeProperty: Property<TimePickerField, string>;
+	/**
+	 * Identifies the {@link timeFormat} dependency property.
+	 */
+	static timeFormatProperty: Property<TimePickerField, string>;
 
-    /**
-     * Identifies the {@link hint} dependency property.
-     */
-    static hintProperty: Property<TimePickerField, string>;
+	/**
+	 * Identifies the {@link locale} dependency property.
+	 */
+	static localeProperty: Property<TimePickerField, string>;
 
-    /**
-     * Identifies the {@link pickerDefaultTime} dependency property.
-     */
-    static pickerDefaultTimeProperty: Property<TimePickerField, string>;
+	/**
+	 * Identifies the {@link hint} dependency property.
+	 */
+	static hintProperty: Property<TimePickerField, string>;
 
-    /**
-     * Identifies the {@link pickerTitle} dependency property.
-     */
-    static pickerTitleProperty: Property<TimePickerField, string>;
+	/**
+	 * Identifies the {@link pickerDefaultTime} dependency property.
+	 */
+	static pickerDefaultTimeProperty: Property<TimePickerField, string>;
 
-    /**
-     * Identifies the {@link pickerOkText} dependency property.
-     */
-    static pickerOkTextProperty: Property<TimePickerField, string>;
+	/**
+	 * Identifies the {@link timeInterval} dependency property.
+	 */
+	static timeIntervalProperty: Property<TimePickerField, number>;
 
-    /**
-     * Identifies the {@link pickerCancelText} dependency property.
-     */
-    static pickerCancelTextProperty: Property<TimePickerField, string>;
+	/**
+	 * Identifies the {@link pickerTitle} dependency property.
+	 */
+	static pickerTitleProperty: Property<TimePickerField, string>;
+
+	/**
+	 * Identifies the {@link pickerOkText} dependency property.
+	 */
+	static pickerOkTextProperty: Property<TimePickerField, string>;
+
+	/**
+	 * Identifies the {@link pickerCancelText} dependency property.
+	 */
+	static pickerCancelTextProperty: Property<TimePickerField, string>;
 }


### PR DESCRIPTION
- iOS 14 compact inline mode is not suitable for the modal time picker, so reverted to default picker mode for time
- Added timeInterval property (1 to 60) to set the minuteInterval of the iOS picker