### PR TITLE
fix(camera): Change UIModalPresentationStyle.CurrentContext to UIModa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@ngtools/webpack": "~11.2.0",
 		"@types/mkdirp": "^1.0.1",
 		"@types/sprintf-js": "^1.1.0",
+		"husky": "^4.3.0",
 		"mkdirp": "^1.0.4",
 		"nativescript-vue": "~2.8.0",
 		"nativescript-vue-template-compiler": "~2.8.0",
@@ -40,8 +41,7 @@
 		"simple-plist": "^1.1.0",
 		"sprintf-js": "^1.1.1",
 		"typescript": "~4.0.3",
-		"zone.js": "~0.11.1",
-		"husky": "^4.3.0"
+		"zone.js": "~0.11.1"
 	},
 	"husky": {
 		"hooks": {

--- a/packages/camera/index.ios.ts
+++ b/packages/camera/index.ios.ts
@@ -162,7 +162,7 @@ export let takePicture = function (options): Promise<any> {
 			imagePickerController.allowsEditing = allowsEditing;
 		}
 
-		imagePickerController.modalPresentationStyle = UIModalPresentationStyle.CurrentContext;
+		imagePickerController.modalPresentationStyle = UIModalPresentationStyle.FullScreen;
 
 		let topMostFrame = Frame.topmost();
 		if (topMostFrame) {


### PR DESCRIPTION
…lPresentationStyle.FullScreen.

iOS camera does not show in nested <page-router-outlets> or when called from a modal.
As discussed in #109 and #78.

Found that the issue for me was the UIModalPresentationStyle. When mixed with the view hierarchy the camera shows behind the modal.
Might also be worth pushing this as an option as my guess is this may change functionality on iPad, but this is not yet tested.