### PR TITLE
fix(datetimepicker): Android Cannot read property 'addEventListener' of undefined

### DIFF
--- a/packages/datetimepicker/ui/date-time-picker-fields.ts
+++ b/packages/datetimepicker/ui/date-time-picker-fields.ts
@@ -257,9 +257,11 @@ export class DateTimePickerFields extends GridLayout {
 	}
 
 	public addEventListener(eventNames: string, callback: (data: EventData) => void, thisArg?: Object) {
-		super.addEventListener(eventNames, callback, thisArg);
-		this.dateField.addEventListener(eventNames, callback, thisArg);
-		this.timeField.addEventListener(eventNames, callback, thisArg);
+		try {
+			super.addEventListener(eventNames, callback, thisArg);
+			this.dateField.addEventListener(eventNames, callback, thisArg);
+			this.timeField.addEventListener(eventNames, callback, thisArg);
+		} catch (e) {}
 	}
 	public removeEventListener(eventNames: string, callback?: any, thisArg?: Object) {
 		super.removeEventListener(eventNames, callback, thisArg);


### PR DESCRIPTION
Adds a try catch to addEventListener function to prevent a crash on Android. Referenced in [#141](https://github.com/NativeScript/plugins/issues/141)
