### PR TITLE
Replacing FingerprintAuth API with Biometric Prompt

### DIFF
--- a/apps/demo-angular/src/plugin-demos/fingerprint-auth.component.html
+++ b/apps/demo-angular/src/plugin-demos/fingerprint-auth.component.html
@@ -4,6 +4,8 @@
 		<StackLayout>
       <Label [text]="demoShared.status" class="t-20 text-center c-black" textWrap="true"></Label>
 			<Button text="Test fingerprint-auth" (tap)="demoShared.doCheckAvailable()" class="btn btn-primary"></Button>
+			<Button text="Test Verify" (tap)="demoShared.doVerifyFingerprint()" class="btn btn-primary"></Button>
+			<Button text="Test Verify w/ PIN Fallback" (tap)="demoShared.doVerifyFingerprintWithCustomFallback()" class="btn btn-primary"></Button>
 		</StackLayout>
 	</ScrollView>
 </StackLayout>

--- a/packages/fingerprint-auth/common.ts
+++ b/packages/fingerprint-auth/common.ts
@@ -11,55 +11,45 @@ export enum ERROR_CODES {
 
 export interface VerifyFingerprintOptions {
   /**
-   * The optional title in the fingerprint page for android.
+   * The required title in the fingerprint page for android.
    * Default: whatever the device default is ('Confirm your password' is likely)
    */
   title?: string;
-
+  /**
+   * The optional subtitle in the fingerprint page for android.
+   * Default: Empty
+   */
+  subTitle?: string;
   /**
    * The optional message in the fingerprint dialog on ios and page description on android.
    * Default: 'Scan your finger' on iOS and the device default on Android (which is likely 'Enter your device password to continue').
    */
   message?: string;
-
   /**
-   * Default 5 (seconds). Can be 0  to always trigger auth.
-   * Android only.
+   * The optional negative button text in the fingerprint page for android.
+   * Default: "Cancel"
    */
-  authenticationValidityDuration?: number;
-
+  cancelText?: string;
   /**
-   * On Android you can either use our fancy proprietary UI or the stock UI Android ships with.
-   * Default false (so use the default UI).
-   * Android only.
+   * The optional confirm button after biometrics have been verified in the fingerprint page for android.
+   * Default: False
    */
-  useCustomAndroidUI?: boolean;
+  confirm?: boolean;
 }
 
-export interface VerifyFingerprintWithCustomFallbackOptions {
-  /**
-   * The optional message in the fingerprint dialog.
-   * Default: 'Scan your finger'.
-   */
-  message?: string;
-
+export interface VerifyFingerprintWithCustomFallbackOptions extends VerifyFingerprintOptions{
   /**
    * The optional button label when scanning the fingerprint fails.
    * Default: 'Enter password'.
    */
   fallbackMessage?: string;
-
-  /**
-   * Default 5 (seconds). Can be 0  to always trigger auth.
-   * Android only.
-   */
-  authenticationValidityDuration?: number;
 }
 
 export interface BiometricIDAvailableResult {
   any: boolean;
   touch?: boolean;
   face?: boolean;
+  biometrics?: boolean;
 }
 
 //noinspection JSUnusedGlobalSymbols

--- a/packages/fingerprint-auth/index.android.ts
+++ b/packages/fingerprint-auth/index.android.ts
@@ -1,15 +1,35 @@
-import { Application, AndroidActivityResultEventData, Utils, AndroidApplication } from "@nativescript/core";
+import { Application, Utils } from "@nativescript/core";
 import { BiometricIDAvailableResult, ERROR_CODES, FingerprintAuthApi, VerifyFingerprintOptions, VerifyFingerprintWithCustomFallbackOptions } from "./common";
 
 declare const com: any;
 
 const KEY_NAME = "fingerprintauth";
 const SECRET_BYTE_ARRAY = Array.create("byte", 16);
-const REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS = 788; // arbitrary
+const AuthenticationCallback = (<any>androidx).biometric.BiometricPrompt.AuthenticationCallback.extend({
+  resolve: null,
+  reject: null,
+  onAuthenticationError(code, error) {
+    this.reject({
+      code: ERROR_CODES.RECOVERABLE_ERROR,
+      message: error
+    });
+  },
+  onAuthenticationFailed() {
+    this.reject({
+      code: ERROR_CODES.NOT_RECOGNIZED,
+      message: "Fingerprint not recognized."
+    });
+  },
+  onAuthenticationSucceeded(result): void {
+    result.getCryptoObject().getCipher().doFinal(SECRET_BYTE_ARRAY);
+    this.resolve();
+  }
+});
 
 export class FingerprintAuth implements FingerprintAuthApi {
   private keyguardManager: android.app.KeyguardManager;
-  private fingerPrintManager: any;
+
+  private biometricPrompt: any;
 
   constructor() {
     this.keyguardManager = Utils.android
@@ -17,7 +37,6 @@ export class FingerprintAuth implements FingerprintAuthApi {
         .getSystemService("keyguard");
   }
 
-  // TODO can we detect face on the Samsung S8?
   available(): Promise<BiometricIDAvailableResult> {
     return new Promise((resolve, reject) => {
       try {
@@ -34,17 +53,15 @@ export class FingerprintAuth implements FingerprintAuthApi {
           return;
         }
 
-        const fingerprintManager = Utils.android
-            .getApplicationContext()
-            .getSystemService(
-                "fingerprint"
-            ) as android.hardware.fingerprint.FingerprintManager;
+        const biometricManager = (<any>androidx).biometric.BiometricManager.from(Utils.android.getApplicationContext());
+        const biometricConstants = (<any>androidx).biometric.BiometricManager;
+        const biometricNoHardwareErrors: Array<number> = [biometricConstants.BIOMETRIC_ERROR_HW_UNAVAILABLE, biometricConstants.BIOMETRIC_ERROR_NO_HARDWARE, biometricConstants.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED, biometricConstants.BIOMETRIC_ERROR_UNSUPPORTED, biometricConstants.BIOMETRIC_ERROR_UNKNOWN];
 
-        if (!fingerprintManager || !fingerprintManager.isHardwareDetected()) {
-          // Device doesn't support fingerprint authentication
-          reject(`Device doesn't support fingerprint authentication`);
-        } else if (!fingerprintManager.hasEnrolledFingerprints()) {
-          // If the user has not enrolled any fingerprints, they still might have the device secure so we can fallback
+        if (!biometricManager || biometricNoHardwareErrors.includes(biometricManager.canAuthenticate())) {
+          // Device doesn't support biometric authentication
+          reject(`Device doesn't support biometric authentication or requires an update`);
+        } else if (biometricManager.canAuthenticate() === (<any>androidx).biometric.BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED) {
+          // If the user has not enrolled any biometrics, they still might have the device secure so we can fallback
           // to present the user with the swipe, password, pin device security screen regardless
           // the developer can handle this resolve by checking the `touch` property and determine if they want to use the
           // verifyFingerprint method or not since they'll know the user has no finger prints enrolled but do have a security option enabled
@@ -52,18 +69,17 @@ export class FingerprintAuth implements FingerprintAuthApi {
           if (this.keyguardManager.isDeviceSecure()) {
             resolve({
               any: true,
-              touch: false
+              biometrics: false
             });
           } else {
-            // User hasn't enrolled any fingerprints to authenticate with
             reject(
-                `User hasn't enrolled any fingerprints to authenticate with`
+                `User hasn't enrolled any biometrics to authenticate with`
             );
           }
-        } else {
+        } else { // Phone has biometric hardware and is enrolled
           resolve({
             any: true,
-            touch: true
+            biometrics: true
           });
         }
       } catch (ex) {
@@ -81,145 +97,60 @@ export class FingerprintAuth implements FingerprintAuthApi {
     });
   }
 
-  private verifyWithCustomAndroidUI(resolve, reject, authenticationCallback) {
-    // this instance is com.jesusm.kfingerprintmanager.KFingerprintManager, not the android OS fingerprint manager
-    this.fingerPrintManager.authenticate(
-        authenticationCallback,
-        this.getActivity().getSupportFragmentManager()
-    );
-  }
-
-  verifyFingerprint(options: VerifyFingerprintOptions): Promise<void | string> {
+  // Following: https://developer.android.com/training/sign-in/biometric-auth#java as a guide
+  verifyFingerprint(options: VerifyFingerprintOptions, pinFallback: boolean = false): Promise<void | string> {
     return new Promise((resolve, reject) => {
       try {
-        // in case 'activity.getSupportFragmentManager' is available ({N} started supporting it,
-        // or the user added our Activity to their Android manifest), use the 3rd party FP library
-        const hasSupportFragment =
-            this.getActivity().getSupportFragmentManager !== undefined;
-
-        if (options.useCustomAndroidUI && !hasSupportFragment) {
+        if (!this.keyguardManager) {
           reject({
-            code: ERROR_CODES.DEVELOPER_ERROR,
-            message:
-                "Custom Fingerprint UI requires changes to AndroidManifest.xml. See the nativescript-fingerprint-auth documentation."
+            code: ERROR_CODES.NOT_AVAILABLE,
+            message: "Keyguard manager not available."
           });
-        } else if (options.useCustomAndroidUI && hasSupportFragment) {
-          if (!this.fingerPrintManager) {
-            this.fingerPrintManager = new com.jesusm.kfingerprintmanager.KFingerprintManager(
-              Utils.android.getApplicationContext(),
-                KEY_NAME
-            );
-          }
-          const that = this;
-          const callback = new com.jesusm.kfingerprintmanager.KFingerprintManager.AuthenticationCallback(
-              {
-                attempts: 0,
-                onAuthenticationFailedWithHelp(help): void {
-                  if (++this.attempts < 3) {
-                    // just invoke the UI again as it's very sensitive (need a timeout to prevent an infinite loop)
-                    setTimeout(
-                        () => that.verifyWithCustomAndroidUI(resolve, reject, this),
-                        50
-                    );
-                  } else {
-                    reject({
-                      code: ERROR_CODES.RECOVERABLE_ERROR,
-                      message: help
-                    });
-                  }
-                },
-                onAuthenticationSuccess(): void {
-                  resolve();
-                },
-                onSuccessWithManualPassword(password): void {
-                  resolve(password);
-                },
-                onFingerprintNotRecognized(): void {
-                  if (++this.attempts < 3) {
-                    // just invoke the UI again as it's very sensitive (need a timeout to prevent an infinite loop)
-                    setTimeout(
-                        () => that.verifyWithCustomAndroidUI(resolve, reject, this),
-                        50
-                    );
-                  } else {
-                    reject({
-                      code: ERROR_CODES.NOT_RECOGNIZED,
-                      message: "Fingerprint not recognized."
-                    });
-                  }
-                },
-                onFingerprintNotAvailable(): void {
-                  reject({
-                    code: ERROR_CODES.NOT_CONFIGURED,
-                    message:
-                        'Secure lock screen hasn\'t been set up.\n Go to "Settings -> Security -> Screenlock" to set up a lock screen.'
-                  });
-                },
-                onCancelled(): void {
-                  reject({
-                    code: ERROR_CODES.PASSWORD_FALLBACK_SELECTED,
-                    message: "Cancelled by user"
-                  });
-                }
-              }
-          );
-          this.verifyWithCustomAndroidUI(resolve, reject, callback);
+        }
+
+        if (this.keyguardManager && !this.keyguardManager.isKeyguardSecure()) {
+          reject({
+            code: ERROR_CODES.NOT_CONFIGURED,
+            message:
+              'Secure lock screen hasn\'t been set up.\n Go to "Settings -> Security -> Screenlock" to set up a lock screen.'
+          });
+        }
+
+        FingerprintAuth.generateSecretKey();
+
+        const cipher = this.getCipher();
+        const secretKey = this.getSecretKey();
+        cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, secretKey);
+        const cryptoObject = new (<any>androidx).biometric.BiometricPrompt.CryptoObject(cipher);
+
+        const executor = (<any>androidx).core.content.ContextCompat.getMainExecutor(Utils.android.getApplicationContext());
+        let authCallback = new AuthenticationCallback();
+        authCallback.resolve = resolve;
+        authCallback.reject = reject;
+
+        this.biometricPrompt = new (<any>androidx).biometric.BiometricPrompt(this.getActivity(), executor, authCallback);
+
+        if (pinFallback) {
+          const info = new (<any>androidx).biometric.BiometricPrompt.PromptInfo.Builder()
+            .setTitle(options.title)
+            .setSubtitle(options.subTitle ? options.subTitle : null)
+            .setDescription(options.message ? options.message : null)
+            .setConfirmationRequired(options.confirm ? options.confirm : false) // Confirm button after verify biometrics=
+            .setAllowedAuthenticators((<any>androidx).biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG | (<any>androidx).biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL) // PIN Fallback or Cancel
+            .build();
+
+          this.biometricPrompt.authenticate(info, cryptoObject);
         } else {
-          const onActivityResult = (data: AndroidActivityResultEventData) => {
-            if (data.requestCode === REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS) {
-              if (data.resultCode === android.app.Activity.RESULT_OK) {
-                // OK = -1
-                // the user has just authenticated via the ConfirmDeviceCredential activity
-                resolve();
-              } else {
-                // the user has quit the activity without providing credentials
-                reject({
-                  code: ERROR_CODES.USER_CANCELLED,
-                  message: "User cancelled."
-                });
-              }
-            }
-            Application.android.off(
-                AndroidApplication.activityResultEvent,
-                onActivityResult
-            );
-          };
+          const info = new (<any>androidx).biometric.BiometricPrompt.PromptInfo.Builder()
+            .setTitle(options.title)
+            .setSubtitle(options.subTitle ? options.subTitle : null)
+            .setDescription(options.message ? options.message : null)
+            .setConfirmationRequired(options.confirm ? options.confirm : false) // Confirm button after verify biometrics=
+            .setNegativeButtonText(options.cancelText ? options.cancelText : "Cancel") // PIN Fallback or Cancel
+            .setAllowedAuthenticators((<any>androidx).biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG) // PIN Fallback or Cancel
+            .build();
 
-          Application.android.on(
-              AndroidApplication.activityResultEvent,
-              onActivityResult
-          );
-
-          if (!this.keyguardManager) {
-            reject({
-              code: ERROR_CODES.NOT_AVAILABLE,
-              message: "Keyguard manager not available."
-            });
-          }
-          if (
-              this.keyguardManager &&
-              !this.keyguardManager.isKeyguardSecure()
-          ) {
-            reject({
-              code: ERROR_CODES.NOT_CONFIGURED,
-              message:
-                  'Secure lock screen hasn\'t been set up.\n Go to "Settings -> Security -> Screenlock" to set up a lock screen.'
-            });
-          }
-
-          FingerprintAuth.createKey(options);
-
-          const tryEncryptResult: boolean = this.tryEncrypt(options);
-          if (tryEncryptResult === undefined) {
-            // this one is async
-          } else if (tryEncryptResult === true) {
-            resolve();
-          } else {
-            reject({
-              code: ERROR_CODES.UNEXPECTED_ERROR,
-              message: "See the console for error logs."
-            });
-          }
+          this.biometricPrompt.authenticate(info, cryptoObject);
         }
       } catch (ex) {
         console.log(`Error in fingerprint-auth.verifyFingerprint: ${ex}`);
@@ -231,125 +162,54 @@ export class FingerprintAuth implements FingerprintAuthApi {
     });
   }
 
-  verifyFingerprintWithCustomFallback(
-      options: VerifyFingerprintWithCustomFallbackOptions
-  ): Promise<any> {
-    return this.verifyFingerprint(options);
+  verifyFingerprintWithCustomFallback(options: VerifyFingerprintWithCustomFallbackOptions): Promise<any> {
+    return this.verifyFingerprint(options, true);
   }
 
   close(): void {
-    const fragmentManager = this.getActivity().getSupportFragmentManager();
-    // this is for custom ui
-    const fragmentTag = "KFingerprintManager:fingerprintDialog";
-    const fragment = fragmentManager.findFragmentByTag(fragmentTag);
-    if (fragment) {
-      fragmentManager.beginTransaction().remove(fragment).commit();
-    } else {
-      // AFAIK it's not possible to programmatically close the standard one
-    }
+    this.biometricPrompt.cancelAuthentication();
   }
 
   /**
    * Creates a symmetric key in the Android Key Store which can only be used after the user has
    * authenticated with device credentials within the last X seconds.
    */
-  private static createKey(options): void {
-    try {
-      const keyStore = java.security.KeyStore.getInstance("AndroidKeyStore");
-      keyStore.load(null);
-      const keyGenerator = javax.crypto.KeyGenerator.getInstance(
-          android.security.keystore.KeyProperties.KEY_ALGORITHM_AES,
-          "AndroidKeyStore"
-      );
-
-      keyGenerator.init(
-          new android.security.keystore.KeyGenParameterSpec.Builder(
-              KEY_NAME,
-              android.security.keystore.KeyProperties.PURPOSE_ENCRYPT |
-              android.security.keystore.KeyProperties.PURPOSE_DECRYPT
-          )
-              .setBlockModes([
-                android.security.keystore.KeyProperties.BLOCK_MODE_CBC
-              ])
-              .setUserAuthenticationRequired(true)
-              .setUserAuthenticationValidityDurationSeconds(
-                  options && options.authenticationValidityDuration
-                      ? options.authenticationValidityDuration
-                      : 5
-              )
-              .setEncryptionPaddings([
-                android.security.keystore.KeyProperties.ENCRYPTION_PADDING_PKCS7
-              ])
-              .build()
-      );
-      keyGenerator.generateKey();
-    } catch (error) {
-      // checks if the AES algorithm is implemented by the AndroidKeyStore
-      if (
-          `${error.nativeException}`.indexOf(
-              "java.security.NoSuchAlgorithmException:"
-          ) > -1
-      ) {
-        // You need a device with API level >= 23 in order to detect if the user has already been authenticated in the last x seconds.
-      }
-    }
-  }
-
-  private tryEncrypt(options): boolean {
-    try {
-      const keyStore = java.security.KeyStore.getInstance("AndroidKeyStore");
-      keyStore.load(null);
-      const secretKey = keyStore.getKey(KEY_NAME, null);
-
-      const cipher = javax.crypto.Cipher.getInstance(
-          `${android.security.keystore.KeyProperties.KEY_ALGORITHM_AES}/${
-              android.security.keystore.KeyProperties.BLOCK_MODE_CBC
-          }/${android.security.keystore.KeyProperties.ENCRYPTION_PADDING_PKCS7}`
-      );
-
-      cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, secretKey);
-      cipher.doFinal(SECRET_BYTE_ARRAY);
-
-      return true;
-    } catch (error) {
-      if (
-          `${error.nativeException}`.indexOf(
-              "android.security.keystore.UserNotAuthenticatedException"
-          ) > -1
-      ) {
-        // the user must provide their credentials in order to proceed
-        this.showAuthenticationScreen(options);
-        return undefined;
-      } else if (
-          `${error.nativeException}`.indexOf(
-              "android.security.keystore.KeyPermanentlyInvalidatedException"
-          ) > -1
-      ) {
-        // Invalid fingerprint
-        console.log(error);
-      } else {
-        console.log(error);
-      }
-      return false;
-    }
-  }
-
-  /**
-   * Starts the built-in Android ConfirmDeviceCredential activity.
-   */
-  private showAuthenticationScreen(options): void {
-    // https://developer.android.com/reference/android/app/KeyguardManager#createConfirmDeviceCredentialIntent(java.lang.CharSequence,%2520java.lang.CharSequence)
-    const intent = (this
-        .keyguardManager as any).createConfirmDeviceCredentialIntent(
-        options && options.title ? options.title : null,
-        options && options.message ? options.message : null
+  private static generateSecretKey(): void {
+    const keyStore = java.security.KeyStore.getInstance("AndroidKeyStore");
+    keyStore.load(null);
+    const keyGenerator = javax.crypto.KeyGenerator.getInstance(
+      android.security.keystore.KeyProperties.KEY_ALGORITHM_AES,
+      "AndroidKeyStore"
     );
-    if (intent !== null) {
-      this.getActivity().startActivityForResult(
-          intent,
-          REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS
-      );
-    }
+
+    keyGenerator.init(
+      new android.security.keystore.KeyGenParameterSpec.Builder(
+        KEY_NAME,
+        android.security.keystore.KeyProperties.PURPOSE_ENCRYPT |
+        android.security.keystore.KeyProperties.PURPOSE_DECRYPT)
+        .setBlockModes([android.security.keystore.KeyProperties.BLOCK_MODE_CBC])
+        .setEncryptionPaddings([android.security.keystore.KeyProperties.ENCRYPTION_PADDING_PKCS7])
+        .setUserAuthenticationRequired(true)
+        .setInvalidatedByBiometricEnrollment(true)
+        // .setUserAuthenticationValidityDurationSeconds(duration ? duration : 5)
+        .build()
+    );
+    keyGenerator.generateKey();
+  }
+
+  private getSecretKey() {
+    const keyStore = java.security.KeyStore.getInstance("AndroidKeyStore");
+
+    // Before the keystore can be accessed, it must be loaded.
+    keyStore.load(null);
+    return keyStore.getKey(KEY_NAME, null);
+  }
+
+  private getCipher(): javax.crypto.Cipher {
+    return javax.crypto.Cipher.getInstance(
+      `${android.security.keystore.KeyProperties.KEY_ALGORITHM_AES}/${android.security.keystore.KeyProperties.BLOCK_MODE_CBC
+      }/${android.security.keystore.KeyProperties.ENCRYPTION_PADDING_PKCS7}`
+    );
   }
 
   private getActivity(): any /* android.app.Activity */ {

--- a/packages/fingerprint-auth/platforms/android/AndroidManifest.xml
+++ b/packages/fingerprint-auth/platforms/android/AndroidManifest.xml
@@ -2,5 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+  <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
 
 </manifest>

--- a/packages/fingerprint-auth/platforms/android/include.gradle
+++ b/packages/fingerprint-auth/platforms/android/include.gradle
@@ -6,5 +6,5 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.github.JesusM:FingerprintManager:v2.0.2'
+	implementation "androidx.biometric:biometric:1.1.0"
 }

--- a/tools/demo/fingerprint-auth/index.ts
+++ b/tools/demo/fingerprint-auth/index.ts
@@ -35,8 +35,7 @@ export class DemoSharedFingerprintAuth extends DemoSharedBase {
 		this.fingerprintAuth
 			.verifyFingerprint({
 				title: 'Enter your password',
-				message: 'Scan yer finger', // optional
-				authenticationValidityDuration: 10, // Android
+				message: 'Scan yer finger' // optional
 			})
 			.then(() => this.set('status', 'Biometric ID / passcode OK'))
 			.catch((err) => {
@@ -51,8 +50,8 @@ export class DemoSharedFingerprintAuth extends DemoSharedBase {
 	doVerifyFingerprintWithCustomUI(): void {
 		this.fingerprintAuth
 			.verifyFingerprint({
+				title: 'Enter your password',
 				message: 'Scan yer finger', // optional
-				useCustomAndroidUI: true, // Android
 			})
 			.then((enteredPassword?: string) => {
 				if (enteredPassword === undefined) {
@@ -72,10 +71,10 @@ export class DemoSharedFingerprintAuth extends DemoSharedBase {
 	doVerifyFingerprintWithCustomFallback(): void {
 		this.fingerprintAuth
 			.verifyFingerprintWithCustomFallback({
+				title: 'Enter your password',
 				message: 'Scan yer finger', // optional
-				fallbackMessage: 'Enter PIN', // optional
-				authenticationValidityDuration: 10, // Android
-			})
+				fallbackMessage: 'Enter PIN' // optional
+			}, true)
 			.then(() => this.set('status', 'Biometric ID OK'))
 			.catch((error) => {
 				this.set('status', 'Biometric ID NOT OK: ' + JSON.stringify(error));


### PR DESCRIPTION
Followed this guide: https://developer.android.com/training/sign-in/biometric-auth#java
Removed some functionality (custom UI's for android) as BiometricPrompt has its own UI now.

Only BIOMETRIC_STRONG authentication is supported which means Face ID will not be 100% supported across all android devices (IE. my galaxy S10e has face (weak/Class 2) and fingerprint (strong/Class 3)).
Newer Face ID (Strong/Class 3) devices should be able to use Face ID though.

This is my first open source PR, looking forward to feedback!

Apologies for the opening and closing of PR's I was signing off my commits instead of signing them.