### PR TITLE
fix(android) [animated-circle]: Uncaught Exception occurred on NS8

### DIFF
--- a/packages/animated-circle/index.android.ts
+++ b/packages/animated-circle/index.android.ts
@@ -311,7 +311,7 @@ export class AnimatedCircle extends AnimatedCircleCommon {
 				this.android.setBarColor([(<Color>this.barColor).argb]);
 			}
 			if (this.fillColor) {
-				this.android.setFillCircleColor((<Color>this.barColor).argb);
+				this.android.setFillCircleColor((<Color>this.fillColor).argb);
 			}
 
 			this.android.setDirection(this.clockwise ? at.grabner.circleprogress.Direction.CW : at.grabner.circleprogress.Direction.CCW);

--- a/packages/animated-circle/index.android.ts
+++ b/packages/animated-circle/index.android.ts
@@ -311,7 +311,7 @@ export class AnimatedCircle extends AnimatedCircleCommon {
 				this.android.setBarColor([(<Color>this.barColor).argb]);
 			}
 			if (this.fillColor) {
-				this.android.setFillCircleColor(new Color(this.fillColor).argb);
+				this.android.setFillCircleColor((<Color>this.barColor).argb);
 			}
 
 			this.android.setDirection(this.clockwise ? at.grabner.circleprogress.Direction.CW : at.grabner.circleprogress.Direction.CCW);


### PR DESCRIPTION
`this.barColor` doesn't need create new instance of `Color`