### PR TITLE
fix(demo): angular demo i18n en file path

### DIFF
--- a/apps/demo-angular/src/i18n/en.default.js
+++ b/apps/demo-angular/src/i18n/en.default.js
@@ -1,3 +1,3 @@
-const translations = require('../../../demo/src/i18n/en.default');
+const translations = require('../../../demo/src/i18n/en');
 translations['app.name'] = 'NSL NG Demo';
 module.exports = translations;


### PR DESCRIPTION
The Angular demo wasn't building for me bc it was referencing
an i18n en.default file that did not exist. I changed the
file path then it built fine.