### PR TITLE
#164 remove default geolocation background perms on Android

### DIFF
--- a/packages/geolocation/platforms/android/AndroidManifest.xml
+++ b/packages/geolocation/platforms/android/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 </manifest>


### PR DESCRIPTION
As discussed in #164, the README already contains explanation about required permissions for always with method `enableLocationRequest`.