### PR TITLE
feat(fingerprint-auth): Make android usage match ios one

### DIFF
--- a/packages/fingerprint-auth/README.md
+++ b/packages/fingerprint-auth/README.md
@@ -60,8 +60,6 @@ fingerprintAuth
 	.verifyFingerprint({
 		title: 'Android title', // optional title (used only on Android)
 		message: 'Scan yer finger', // optional (used on both platforms) - for FaceID on iOS see the notes about NSFaceIDUsageDescription
-		authenticationValidityDuration: 10, // optional (used on Android, default 5)
-		useCustomAndroidUI: false, // set to true to use a different authentication screen (see below)
 	})
 	.then((enteredPassword?: string) => {
 		if (enteredPassword === undefined) {
@@ -71,57 +69,6 @@ fingerprintAuth
 		}
 	})
 	.catch((err) => console.log(`Biometric ID NOT OK: ${JSON.stringify(err)}`));
-```
-
-#### A nicer UX/UI on Android (`useCustomAndroidUI: true`)
-
-The default authentication screen on Android is a standalone screen that (depending on the exact Android version) looks kinda 'uninteresting'.
-So with version 6.0.0 this plugin added the ability to override the default screen and offer an iOS popover style which you can activate by passing in `useCustomAndroidUI: true` in the function above.
-
-One important thing to realize is that the 'use password' option in this dialog doesn't verify the entered password against
-the system password. It must be used to compare the entered password with an app-specific password the user previously configured.
-
-The password fallback can be disabled by overriding the default `use_password` text to a blank string (see optional change below for details on how to do this).
-
-##### Optional change
-
-If you want to override the default texts of this popover screen, then drop a file [`strings.xml`](https://github.com/EddyVerbruggen/nativescript-fingerprint-auth/blob/5a14f96f7e752953df506401588b5694e3ab6444/demo/app/App_Resources/Android/src/main/res/values/strings.xml) in your project and override the properties you like. See the demo app for an example.
-
-##### ⚠️ Important note when using NativeScript < 5.4.0
-
-**Use plugin version < 7.0.0 to be able to use this feature with NativeScript < 5.4.0**
-
-> **Note**: Skip this section if you're on NativeScript 5.4.0 or newer because it's all handled automatically!
-
-To be able to use this screen, a change to `App_Resources/Android/AndroidManifest.xml` is required as our NativeScript activity needs to extend AppCompatActivity (note that in the future this may become the default for NativeScript apps).
-
-To do so, open the file and replace `<activity android:name="com.tns.NativeScriptActivity"` by `<activity android:name="org.nativescript.fingerprintplugin.AppCompatActivity"`.
-
-Note that if you forget this and set `useCustomAndroidUI: true` the plugin will `reject` the Promise with a relevant error message.
-
-**Mandatory changes for webpack and snapshot builds (again, for NativeScript < 5.4.0 only)**
-
-If you are using Webpack with or without snapshot there are couple more changes required in order to make the custom UI work in your production builds.  
-First you need to edit your `vendor-platform.android.ts` file and add `require("nativescript-fingerprint-auth/appcompat-activity");`. You can see the changed file in the demo app [here](https://github.com/EddyVerbruggen/nativescript-fingerprint-auth/blob/6.2.0/demo/app/vendor-platform.android.ts).  
-The second change should be made in your `webpack.config.js` file. Find the place where the `NativeScriptSnapshotPlugin` is pushed to the webpack plugins and add `"nativescript-fingerprint-auth"` in the `tnsJavaClassesOptions.packages` array. The result should look something like:
-
-```js
-// ...
-if (snapshot) {
-	config.plugins.push(
-		new nsWebpack.NativeScriptSnapshotPlugin({
-			chunk: 'vendor',
-			projectRoot: __dirname,
-			webpackConfig: config,
-			targetArchs: ['arm', 'arm64', 'ia32'],
-			tnsJavaClassesOptions: {
-				packages: ['tns-core-modules', '@nativescript/fingerprint-auth'],
-			},
-			useLibs: false,
-		})
-	);
-}
-// ...
 ```
 
 ### `verifyFingerprintWithCustomFallback` (iOS only, falls back to `verifyFingerprint` on Android)

--- a/packages/fingerprint-auth/common.ts
+++ b/packages/fingerprint-auth/common.ts
@@ -26,11 +26,6 @@ export interface VerifyFingerprintOptions {
 	 */
 	message?: string;
 	/**
-	 * The optional negative button text in the fingerprint page for android.
-	 * Default: "Cancel"
-	 */
-	cancelText?: string;
-	/**
 	 * The optional confirm button after biometrics have been verified in the fingerprint page for android.
 	 * Default: False
 	 */

--- a/packages/fingerprint-auth/index.android.ts
+++ b/packages/fingerprint-auth/index.android.ts
@@ -95,7 +95,7 @@ export class FingerprintAuth implements FingerprintAuthApi {
 	}
 
 	// Following: https://developer.android.com/training/sign-in/biometric-auth#java as a guide
-	verifyFingerprint(options: VerifyFingerprintOptions, pinFallback: boolean = false): Promise<void | string> {
+	verifyFingerprint(options: VerifyFingerprintWithCustomFallbackOptions, pinFallback: boolean = false): Promise<void | string> {
 		return new Promise((resolve, reject) => {
 			try {
 				if (!this.keyguardManager) {

--- a/packages/fingerprint-auth/index.android.ts
+++ b/packages/fingerprint-auth/index.android.ts
@@ -128,7 +128,7 @@ export class FingerprintAuth implements FingerprintAuthApi {
 
 				if (pinFallback) {
 					const info = new (<any>androidx).biometric.BiometricPrompt.PromptInfo.Builder()
-						.setTitle(options.title)
+						.setTitle(options.title ? options.title : "Login")
 						.setSubtitle(options.subTitle ? options.subTitle : null)
 						.setDescription(options.message ? options.message : null)
 						.setConfirmationRequired(options.confirm ? options.confirm : false) // Confirm button after verify biometrics=
@@ -138,11 +138,11 @@ export class FingerprintAuth implements FingerprintAuthApi {
 					this.biometricPrompt.authenticate(info, cryptoObject);
 				} else {
 					const info = new (<any>androidx).biometric.BiometricPrompt.PromptInfo.Builder()
-						.setTitle(options.title)
+						.setTitle(options.title ? options.title : "Login")
 						.setSubtitle(options.subTitle ? options.subTitle : null)
 						.setDescription(options.message ? options.message : null)
 						.setConfirmationRequired(options.confirm ? options.confirm : false) // Confirm button after verify biometrics=
-						.setNegativeButtonText(options.cancelText ? options.cancelText : 'Cancel') // PIN Fallback or Cancel
+						.setNegativeButtonText(options.fallbackMessage ? options.fallbackMessage : 'Enter your password') // PIN Fallback or Cancel
 						.setAllowedAuthenticators((<any>androidx).biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG) // PIN Fallback or Cancel
 						.build();
 
@@ -159,7 +159,7 @@ export class FingerprintAuth implements FingerprintAuthApi {
 	}
 
 	verifyFingerprintWithCustomFallback(options: VerifyFingerprintWithCustomFallbackOptions): Promise<any> {
-		return this.verifyFingerprint(options, true);
+		return this.verifyFingerprint(options, false);
 	}
 
 	close(): void {


### PR DESCRIPTION
After v8 rewrite seems the usage for android was messed up:
* A new property `cancelText` was added. This is unneeded since we already have a property that is used for iOS for the same thing - `fallbackMessage`.
* The `verifyFingerprintWithCustomFallback` was made so that it always prompts for pin. This is not correct since the same method for iOS is added exactly for not allowing pin entry. 
* In v7 a title was not required but in v8 the plugin crashes if no title is added (#203)
* Readme was not adjusted to eliminate the custom android UI which is not used anymore as well as the authentication validity timeout which is also unused. 

This PR changes the above so usage in both platforms is more standardized. 

Close #203 