### PR TITLE
chose: froze nativescript-permissions version to 1.3.11 in plugins th…

### DIFF
--- a/packages/camera/package.json
+++ b/packages/camera/package.json
@@ -35,6 +35,6 @@
   "readmeFilename": "README.md",
   "bootstrapper": "@nativescript/plugin-seed",
   "dependencies": {
-    "nativescript-permissions": "~1.3.0"
+    "nativescript-permissions": "1.3.11"
   }
 }

--- a/packages/geolocation/package.json
+++ b/packages/geolocation/package.json
@@ -33,6 +33,6 @@
   "readmeFilename": "README.md",
   "bootstrapper": "@nativescript/plugin-seed",
   "dependencies": {
-    "nativescript-permissions": "~1.3.0"
+    "nativescript-permissions": "1.3.11"
   }
 }

--- a/packages/imagepicker/package.json
+++ b/packages/imagepicker/package.json
@@ -33,6 +33,6 @@
 	"readmeFilename": "README.md",
 	"bootstrapper": "@nativescript/plugin-seed",
 	"dependencies": {
-		"nativescript-permissions": "~1.3.0"
+		"nativescript-permissions": "1.3.11"
 	}
 }


### PR DESCRIPTION
nativescript-permissions plugin had a breaking change going from version 1.3.11 to 1.3.12 and plugins that depend on it no longer work properly. This PR freezes the version at 1.3.11 instead of using the tilde to receive the patch update to 1.3.12 automatically.