### PR TITLE
chore: update readme

### DIFF
--- a/packages/fingerprint-auth/README.md
+++ b/packages/fingerprint-auth/README.md
@@ -1,3 +1,7 @@
+## Replacement notice
+
+This plugin is replaced by [@nativescript/biometrics](../biometrics)
+
 # @nativescript/fingerprint-auth
 
 ```cli


### PR DESCRIPTION
Update readme to point to new biometrics plugin which replaces fingerprint-auth.