### PR TITLE
fix(datetimepicker) angular ios spinner style seems to break after first use (ns-dark)

### DIFF
--- a/packages/datetimepicker/common.ts
+++ b/packages/datetimepicker/common.ts
@@ -92,9 +92,8 @@ function getColorsForClassName(view: View, className: string): { color: Color; b
 	if (vueKey) {
 		tempView[vueKey] = view[vueKey];
 	}
-	if (view.className) {
-		let classNames = view.className.split(' ');
-		classNames.forEach((element) => {
+	if (view.cssClasses && view.cssClasses.length > 0) {
+		view.cssClasses.forEach((element) => {
 			tempView.cssClasses.add(element);
 		});
 	}


### PR DESCRIPTION
This fixes the bright background on picker view on ios like described here: https://github.com/NativeScript/plugins/issues/34#issuecomment-1081736598

#fixes https://github.com/NativeScript/plugins/issues/34
#mayfixes https://github.com/NativeScript/plugins/issues/65