### PR TITLE
chore(auto-fit-text): migrate from deprecated compile gradle API

### DIFF
--- a/packages/auto-fit-text/platforms/android/include.gradle
+++ b/packages/auto-fit-text/platforms/android/include.gradle
@@ -1,9 +1,9 @@
 /* Include.gradle configuration: http://docs.nativescript.org/plugins/plugins#includegradle-specification */
 
 android {
-	
+
 }
 
 dependencies {
-	 compile 'me.grantland:autofittextview:0.2.+'
+	 implementation 'me.grantland:autofittextview:0.2.+'
 }


### PR DESCRIPTION
Gradle build cannot complete when using android build-tools 32.x.x+