### PR TITLE
chore(localize): skip lib check to avoid TS compile errors

### DIFF
--- a/packages/localize/hooks/tsconfig.json
+++ b/packages/localize/hooks/tsconfig.json
@@ -10,7 +10,8 @@
 		"emitDecoratorMetadata": true,
 		"noEmitHelpers": false,
 		"noEmitOnError": true,
-		"removeComments": true
+		"removeComments": true,
+		"skipLibCheck": true
 	},
 	"include": ["../typings/**/*.d.ts"],
 	"files": ["index.ts"]


### PR DESCRIPTION
The way bplist-parser exposes its functionality prevents TS from compiling this plugin using TS 4.5+