### PR TITLE
Add additional provider paths to @nativescript/camera

### DIFF
--- a/packages/camera/platforms/android/res/xml/provider_paths.xml
+++ b/packages/camera/platforms/android/res/xml/provider_paths.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-     <external-path
+	<root-path
+    name="root"
+    path="." />
+  <external-path
     name="external"
     path="." />
   <external-files-path
@@ -12,7 +15,7 @@
   <external-cache-path
     name="external_cache"
     path="." />
-<files-path
+  <files-path
     name="files"
     path="." />
 </paths>


### PR DESCRIPTION
See my comment on https://github.com/NativeScript/plugins/issues/252

This fixes the error for android 12 in my case. 
Also tidied up the file formatting slightly.