### PR TITLE
 bump GoogleMaps pod to 6.2.1

### DIFF
--- a/packages/google-maps/platforms/ios/Podfile
+++ b/packages/google-maps/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'GoogleMaps', '6.0.1'
+pod 'GoogleMaps', '6.2.1'


### PR DESCRIPTION
Bumps the GoogleMaps pod to 6.2.1 on `@nativescript/google-maps`.

To help deal with the Metal Sim crash issue: https://issuetracker.google.com/issues/208593323

Have not dumped the typedefs to see if there's any other major changes yet but seems to work as expected.

Can use `npm i --E @codesthings/google-maps@1.1.3 @nativescript/google-maps@npm:@codesthings/google-maps@1.1.3` to test on a local project.