### PR TITLE
Update index.ios.ts to remove callback on cancel of DateTimePicker dialog.

### DIFF
--- a/packages/datetimepicker/index.ios.ts
+++ b/packages/datetimepicker/index.ios.ts
@@ -143,7 +143,7 @@ export class DateTimePicker extends DateTimePickerBase {
 		const okButtonText = options.okButtonText ? options.okButtonText : 'OK';
 		const cancelActionStyle = style && style.buttonCancelBackgroundColor ? UIAlertActionStyle.Default : UIAlertActionStyle.Cancel;
 		let cancelAction = UIAlertAction.actionWithTitleStyleHandler(cancelButtonText, cancelActionStyle, () => {
-			callback(null);
+			//callback(null);
 		});
 		let okAction = UIAlertAction.actionWithTitleStyleHandler(okButtonText, UIAlertActionStyle.Default, () => {
 			callback(pickerView.date);


### PR DESCRIPTION
Removed callback(null) for cancelAction in iOS. If left in this results in datePickerClosed event being called.