### PR TITLE
fix(google-signin ios): define serverClientId as optional parameter i…

### DIFF
--- a/packages/google-signin/common.ts
+++ b/packages/google-signin/common.ts
@@ -4,6 +4,7 @@ export interface Configuration {
 	scopes?: string[];
 	signInOptions?: 'default' | 'games';
 	clientId?: string;
+	serverClientId?: string;
 	accountName?: string;
 	hostedDomain?: string;
 }

--- a/packages/google-signin/index.ios.ts
+++ b/packages/google-signin/index.ios.ts
@@ -124,7 +124,7 @@ export class GoogleSignin {
 
 			let serverClientId;
 			if (configuration['serverClientId']) {
-				clientId = configuration['serverClientId'];
+				serverClientId = configuration['serverClientId'];
 			} else {
 				if (!plist) {
 					plist = NSDictionary.alloc().initWithContentsOfFile(path);


### PR DESCRIPTION
…n Configuration-interface and do not overwrite clientId variable when serverClientId-parameter is provided in options