### PR TITLE
feat(biometrics): improve android fallback messaging

### DIFF
--- a/packages/biometrics/README.md
+++ b/packages/biometrics/README.md
@@ -48,7 +48,7 @@ class MyClass {
 
 ### `verifyBiometric`
 
-Note that on the iOS simulator use Features->Face ID  menu items to enroll a face and signal successs/failure to recognize a face.
+Note that on the iOS simulator use Features->Face ID menu items to enroll a face and signal successs/failure to recognize a face.
 verifyBiometric will fail on IOS simulator unless pinfallBack is used.
 
 ```typescript
@@ -56,11 +56,13 @@ biometricAuth
 	.verifyBiometric({
 		title: 'Android title', // optional title (used only on Android)
 		message: 'Scan yer finger', // optional (used on both platforms) - for FaceID on iOS see the notes about NSFaceIDUsageDescription
+		fallbackMessage: 'Enter your PIN', // this will be the text to show for the "fallback" button on the biometric prompt
+		pinFallback: true, // allow fall back to pin/password
 	})
 	.then((result?: BiometricResult) => {
 		if (result.code === ERROR_CODES.SUCCESS) {
 			console.log('Biometric ID OK');
-		} 
+		}
 	})
 	.catch((err) => console.log(`Biometric ID NOT OK: ${JSON.stringify(err)}`));
 ```
@@ -106,69 +108,63 @@ biometricAuth.available().then((avail) => {
 
 ### Normal operation
 
-If you do not pass any of the options (pinFallback / keyName) to the verify method then the plugin will create a secure key, call the authorization methods to trigger face/fingerprint and then attempt to use the key to encrypt some text.  The idea being that the key will not be accessable unless the user has successfully authenticated.
+If you do not pass any of the options (pinFallback / keyName) to the verify method then the plugin will create a secure key, call the authorization methods to trigger face/fingerprint and then attempt to use the key to encrypt some text. The idea being that the key will not be accessable unless the user has successfully authenticated.
 
-This however is not foolproof and the most secure method is to pass the  ```secret```  and ```Keyname```options to encrypt/decrypt text.
+This however is not foolproof and the most secure method is to pass the `secret` and `Keyname`options to encrypt/decrypt text.
 
 ### Encrypting/Decrypting with Authentication
 
-The best practice is to use the options to encrypt some secret that is validated independently, this is more secure because the key used for decryption cannot be accessed without proper authentication,  therefor your secret cannot be decrypted properly.
+The best practice is to use the options to encrypt some secret that is validated independently, this is more secure because the key used for decryption cannot be accessed without proper authentication, therefor your secret cannot be decrypted properly.
 
 1.  Encrypt your secret
 
-	Call ```verifyBiometric``` with the relevant properties.
+    Call `verifyBiometric` with the relevant properties.
 
-	```ts
-	biometricAuth
-		.verifyBiometric({
-			title: 'Enter your password',
-			message: 'Scan yer finger', // optional
-			pinFallback: false, // do not allow pnFallback to enable crypto operations
-			keyName: 'MySecretKeyName', // The name of the key that will be created/used
-			secret: 'The Secret I want encrypted' }
-			)
-		.then((result) => {
-			var encryptedText= result.encrypted  // The text encrypted with a key named "MySecretKeyName" (Android Only)
-			var IV = result.iv // the  initialization vector used to encrypt (Android Only)
+    ```ts
+    biometricAuth
+    	.verifyBiometric({
+    		title: 'Enter your password',
+    		message: 'Scan yer finger', // optional
+    		pinFallback: false, // do not allow pinFallback to enable crypto operations
+    		keyName: 'MySecretKeyName', // The name of the key that will be created/used
+    		secret: 'The Secret I want encrypted',
+    	})
+    	.then((result) => {
+    		const encryptedText = result.encrypted; // The text encrypted with a key named "MySecretKeyName" (Android Only)
+    		const IV = result.iv; // the  initialization vector used to encrypt (Android Only)
 
-			// For IOS the secret is stored in the keycain 
-			
-			
-		})
-		.catch((err) => this.set('status', `Biometric ID NOT OK: " + ${JSON.stringify(err)}`));
+    		// For IOS the secret is stored in the keycain
+    	})
+    	.catch((err) => this.set('status', `Biometric ID NOT OK: " + ${JSON.stringify(err)}`));
+    ```
 
-	```
-
-	For Android the encrypted result and vector would then be stored in your app and used the next time the user logged in be calling the ```verifyBiometric``` again:
+    For Android the encrypted result and vector would then be stored in your app and used the next time the user logged in be calling the `verifyBiometric` again:
 
 1.  Decrypt your secret
-	```ts
-	biometricAuth
-		.verifyBiometric({
-			title: 'Enter your password',
-			message: 'Scan yer finger', // optional
-			keyName: 'MySecretKeyName', // The name of the key that will be created/used
-			pinFallback: false, // do not allow pnFallback to enable crypto operations
-			android: { 
-					
-					decryptText: 'The encrypted text retrieved previously',
-					iv: 'The IV retrieved previously` },
-			ios: { fetchSecret: true } // Tell IOS to fetch the secret
 
-		})
-		.then((result) => {
-			var decryptedText= result.decrypted  // The unencrypted secret 
-			verifyMySecret(decryptedText) // verify the secret by some means, e.g. a call to a back end server.
-			
-			
-		})
-		.catch((err) => this.set('status', `Biometric ID NOT OK: " + ${JSON.stringify(err)}`));
-
-	```
+    ```ts
+    biometricAuth
+    	.verifyBiometric({
+    		title: 'Enter your password',
+    		message: 'Scan yer finger', // optional
+    		keyName: 'MySecretKeyName', // The name of the key that will be created/used
+    		pinFallback: false, // do not allow pinFallback to enable crypto operations
+    		android: {
+    			decryptText: 'The encrypted text retrieved previously',
+    			iv: 'The IV retrieved previously',
+    		},
+    		ios: { fetchSecret: true }, // Tell IOS to fetch the secret
+    	})
+    	.then((result) => {
+    		const decryptedText = result.decrypted; // The unencrypted secret
+    		verifyMySecret(decryptedText); // verify the secret by some means, e.g. a call to a back end server.
+    	})
+    	.catch((err) => this.set('status', `Biometric ID NOT OK: " + ${JSON.stringify(err)}`));
+    ```
 
 ### Fallback to Pin
 
-Allowing the user to fallback on lock screen credentials ( pin etc. ) disables cryptography.  
+Allowing the user to fallback on lock screen credentials ( pin etc. ) disables cryptography.
 
 Also on android for phones running API < 30 only fingerprint is used, because the old fingerprint api is called.
 
@@ -180,17 +176,14 @@ biometricAuth
 		title: 'Enter your password',
 		message: 'Scan yer finger', // optional
 		fallbackMessage: 'Enter PIN', // optional
-		pinFallback: true, // allow pnFallback to enable crypto operations
+		pinFallback: true, // do not allow pinFallback to enable crypto operations
 		ios: { customFallback: false }, // passing true here will show the fallback message and allow you to handle this in a custom manner.
 	})
 	.then((result) => {
 		console.log('Fingerprint/ PIN was OK');
-		
 	})
 	.catch((err) => this.set('status', `Biometric ID NOT OK: " + ${JSON.stringify(err)}`));
-
 ```
-
 
 ## License
 

--- a/packages/biometrics/index.android.ts
+++ b/packages/biometrics/index.android.ts
@@ -36,7 +36,7 @@ const AuthenticationCallback = (<any>androidx.biometric.BiometricPrompt.Authenti
 
 		this.reject({
 			code: returnCode,
-			message,
+			message
 		});
 	},
 	onAuthenticationFailed() {
@@ -58,10 +58,16 @@ const AuthenticationCallback = (<any>androidx.biometric.BiometricPrompt.Authenti
 			} else if (this.toDecrypt) {
 				const nativeBytes = android.util.Base64.decode(this.toDecrypt, android.util.Base64.DEFAULT);
 
-				const decryptedBytes = result.getCryptoObject().getCipher().doFinal(nativeBytes);
+				const decryptedBytes = result
+					.getCryptoObject()
+					.getCipher()
+					.doFinal(nativeBytes);
 				decrypted = new java.lang.String(decryptedBytes, java.nio.charset.StandardCharsets.UTF_8).toString();
 			} else if (!this.pinFallBack) {
-				result.getCryptoObject().getCipher().doFinal(SECRET_BYTE_ARRAY);
+				result
+					.getCryptoObject()
+					.getCipher()
+					.doFinal(SECRET_BYTE_ARRAY);
 			}
 
 			this.resolve({
@@ -69,16 +75,16 @@ const AuthenticationCallback = (<any>androidx.biometric.BiometricPrompt.Authenti
 				message: 'All OK',
 				encrypted,
 				decrypted,
-				iv,
+				iv
 			});
 		} catch (error) {
 			console.log(`Error in onAuthenticationSucceeded: ${error}`);
 			this.reject({
 				code: ERROR_CODES.UNEXPECTED_ERROR,
-				message: error,
+				message: error
 			});
 		}
-	},
+	}
 });
 
 export class BiometricAuth implements BiometricApi {
@@ -95,7 +101,7 @@ export class BiometricAuth implements BiometricApi {
 			try {
 				if (!this.keyguardManager || !this.keyguardManager.isKeyguardSecure()) {
 					resolve({
-						any: false,
+						any: false
 					});
 					return;
 				}
@@ -122,7 +128,7 @@ export class BiometricAuth implements BiometricApi {
 					if (this.keyguardManager.isDeviceSecure()) {
 						resolve({
 							any: true,
-							biometrics: false,
+							biometrics: false
 						});
 					} else {
 						reject(`User hasn't enrolled any biometrics to authenticate with`);
@@ -131,7 +137,7 @@ export class BiometricAuth implements BiometricApi {
 					// Phone has biometric hardware and is enrolled
 					resolve({
 						any: true,
-						biometrics: true,
+						biometrics: true
 					});
 				}
 			} catch (ex) {
@@ -141,16 +147,16 @@ export class BiometricAuth implements BiometricApi {
 		});
 	}
 
-    // Following: https://stackoverflow.com/questions/61193681/check-if-the-user-changed-biometric-fingerprint-in-android as a guide
-    didBiometricDatabaseChange(): Promise<boolean> {
+	// Following: https://stackoverflow.com/questions/61193681/check-if-the-user-changed-biometric-fingerprint-in-android as a guide
+	didBiometricDatabaseChange(): Promise<boolean> {
 		return new Promise((resolve, reject) => {
 			const options = {};
-            const cipher = this.getCipher();
-            var secretKey = this.getSecretKey(KEY_NAME);
-            if (secretKey === null) {
-                BiometricAuth.generateSecretKey(options, reject);
-                secretKey = this.getSecretKey(KEY_NAME);
-            }
+			const cipher = this.getCipher();
+			var secretKey = this.getSecretKey(KEY_NAME);
+			if (secretKey === null) {
+				BiometricAuth.generateSecretKey(options, reject);
+				secretKey = this.getSecretKey(KEY_NAME);
+			}
 			try {
 				cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, secretKey);
 			} catch (ex) {
@@ -158,13 +164,13 @@ export class BiometricAuth implements BiometricApi {
 				try {
 					BiometricAuth.generateSecretKey(options, reject);
 					resolve(true);
-                } catch (e) {
+				} catch (e) {
 					console.log(`Error when generating new key: ${ex}`);
 				}
 			}
-            resolve(false);
+			resolve(false);
 		});
-    }
+	}
 
 	// Following: https://developer.android.com/training/sign-in/biometric-auth#java as a guide
 	verifyBiometric(options: VerifyBiometricOptions): Promise<BiometricResult> {
@@ -173,14 +179,14 @@ export class BiometricAuth implements BiometricApi {
 				if (!this.keyguardManager) {
 					reject({
 						code: ERROR_CODES.NOT_AVAILABLE,
-						message: 'Keyguard manager not available.',
+						message: 'Keyguard manager not available.'
 					});
 				}
 
 				if (this.keyguardManager && !this.keyguardManager.isKeyguardSecure()) {
 					reject({
 						code: ERROR_CODES.NOT_CONFIGURED,
-						message: 'Secure lock screen hasn\'t been set up.\n Go to "Settings -> Security -> Screenlock" to set up a lock screen.',
+						message: 'Secure lock screen hasn\'t been set up.\n Go to "Settings -> Security -> Screenlock" to set up a lock screen.'
 					});
 				}
 				const pinFallback = options?.pinFallback;
@@ -219,7 +225,7 @@ export class BiometricAuth implements BiometricApi {
 						.setSubtitle(options.subTitle ? options.subTitle : null)
 						.setDescription(options.message ? options.message : null)
 						.setConfirmationRequired(options.confirm ? options.confirm : false) // Confirm button after verify biometrics=
-						.setNegativeButtonText(options.fallbackMessage ? options.fallbackMessage : 'Enter your password') // PIN Fallback or Cancel
+						.setNegativeButtonText(options.fallbackMessage ? options.fallbackMessage : 'Cancel') // PIN Fallback or Cancel
 						.setAllowedAuthenticators(androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG) // PIN Fallback or Cancel
 						.build();
 
@@ -229,7 +235,7 @@ export class BiometricAuth implements BiometricApi {
 				console.log(`Error in biometrics-auth.verifyBiometric: ${ex}`);
 				reject({
 					code: ERROR_CODES.UNEXPECTED_ERROR,
-					message: ex,
+					message: ex
 				});
 			}
 		});
@@ -275,14 +281,17 @@ export class BiometricAuth implements BiometricApi {
 				if (options.android?.decryptText) {
 					reject({
 						code: ERROR_CODES.UNEXPECTED_ERROR,
-						message: `Key not available: ${keyName}`,
+						message: `Key not available: ${keyName}`
 					});
 				}
 			}
 		}
 
 		const keyGenerator = javax.crypto.KeyGenerator.getInstance(android.security.keystore.KeyProperties.KEY_ALGORITHM_AES, 'AndroidKeyStore');
-		const builder = new android.security.keystore.KeyGenParameterSpec.Builder(keyName, android.security.keystore.KeyProperties.PURPOSE_ENCRYPT | android.security.keystore.KeyProperties.PURPOSE_DECRYPT).setBlockModes([android.security.keystore.KeyProperties.BLOCK_MODE_CBC]).setEncryptionPaddings([android.security.keystore.KeyProperties.ENCRYPTION_PADDING_PKCS7]).setUserAuthenticationRequired(true);
+		const builder = new android.security.keystore.KeyGenParameterSpec.Builder(keyName, android.security.keystore.KeyProperties.PURPOSE_ENCRYPT | android.security.keystore.KeyProperties.PURPOSE_DECRYPT)
+			.setBlockModes([android.security.keystore.KeyProperties.BLOCK_MODE_CBC])
+			.setEncryptionPaddings([android.security.keystore.KeyProperties.ENCRYPTION_PADDING_PKCS7])
+			.setUserAuthenticationRequired(true);
 		if (android.os.Build.VERSION.SDK_INT > 23) {
 			builder.setInvalidatedByBiometricEnrollment(true);
 		}
@@ -297,14 +306,14 @@ export class BiometricAuth implements BiometricApi {
 					// the user has just authenticated via the ConfirmDeviceCredential activity
 					resolve({
 						code: ERROR_CODES.SUCCESS,
-						message: 'All OK',
+						message: 'All OK'
 					});
 				} else {
 					// the user has quit the activity without providing credendials
 
 					reject({
 						code: ERROR_CODES.USER_CANCELLED,
-						message: 'User cancelled.',
+						message: 'User cancelled.'
 					});
 				}
 			}


### PR DESCRIPTION
This changes the default "fallbackMessage" on Android to `Cancel` when `pinFallback` is not set. Currently "Enter your password" was the text and this was being set on the "negative button text" on the android prompt, causing confusion and a bad UX when the user was not allowed to enter a pin and they'd see the bottom left negative button with that default text.