### PR TITLE
Feat(google maps)/camera move

### DIFF
--- a/packages/google-maps/index.android.ts
+++ b/packages/google-maps/index.android.ts
@@ -766,6 +766,10 @@ export class GoogleMap implements IGoogleMap {
 		}
 	}
 
+	moveCamera(update: CameraUpdate) {
+		this.native.moveCamera(update.native);
+	}
+
 	animateCamera(update: CameraUpdate) {
 		this.native.animateCamera(update.native);
 	}

--- a/packages/google-maps/index.d.ts
+++ b/packages/google-maps/index.d.ts
@@ -452,6 +452,8 @@ export class GoogleMap implements IGoogleMap {
 
 	removePolyline(polyline: Polyline);
 
+	moveCamera(update: CameraUpdate);
+
 	animateCamera(update: CameraUpdate);
 
 	snapshot(): Promise<ImageSource>;

--- a/packages/google-maps/index.ios.ts
+++ b/packages/google-maps/index.ios.ts
@@ -911,6 +911,10 @@ export class GoogleMap implements IGoogleMap {
 		return polyline;
 	}
 
+	moveCamera(update: CameraUpdate) {
+		this.native.moveCamera(update.native);
+	}
+
 	animateCamera(update: CameraUpdate) {
 		this.native.animateWithCameraUpdate(update.native);
 	}

--- a/packages/google-maps/index.ios.ts
+++ b/packages/google-maps/index.ios.ts
@@ -781,7 +781,7 @@ export class GoogleMap implements IGoogleMap {
 	}
 
 	set cameraPosition(value) {
-		this.native.camera = value.native;
+		this.native.moveCamera(CameraUpdate.fromCameraPosition(value).native);
 	}
 
 	get maxZoomLevel(): number {


### PR DESCRIPTION
iOS was incorrectly trying to set it's location from a non-CameraPosition type object. 
Updated to use the CameraPosition with the setter like Android. 
Added moveCamera function for non-animated camera events.
Fixes #291 