### PR TITLE
fix(google maps): missing setters for some uiSettings

### DIFF
--- a/packages/google-maps/index.android.ts
+++ b/packages/google-maps/index.android.ts
@@ -623,6 +623,10 @@ export class UISettings implements IUISettings {
 		return this.native.isRotateGesturesEnabled();
 	}
 
+	set rotateGesturesEnabled(value) {
+		this.native.setRotateGesturesEnabled(value);
+	}
+
 	get myLocationButtonEnabled(): boolean {
 		return this.native.isMyLocationButtonEnabled();
 	}
@@ -635,8 +639,16 @@ export class UISettings implements IUISettings {
 		return this.native.isIndoorLevelPickerEnabled();
 	}
 
+	set indoorLevelPickerEnabled(value) {
+		this.native.setIndoorLevelPickerEnabled(value);
+	}
+
 	get scrollGesturesEnabled(): boolean {
 		return this.native.isScrollGesturesEnabled();
+	}
+
+	set scrollGesturesEnabled(value) {
+		this.native.setScrollGesturesEnabled(value);
 	}
 }
 


### PR DESCRIPTION
Added android setters for:
 * `rotateGesturesEnabled`
 * `indoorLevelPickerEnabled`
 * `scrollGesturesEnabled`

closes #334