### PR TITLE
feat(google-maps): Export common enums

### DIFF
--- a/packages/google-maps/index.d.ts
+++ b/packages/google-maps/index.d.ts
@@ -749,3 +749,5 @@ export class TileProvider implements ITileProvider {
 export class UrlTileProvider extends TileProvider {
 	constructor(callback: (x: number, y: number, zoom: number) => string, size?: number);
 }
+
+export { MapType, JointType };


### PR DESCRIPTION
Common enums for MapType and JointType were missing from export.