### PR TITLE
feat(social-share): support sharing a caption alongside images and PDFs

### DIFF
--- a/packages/social-share/index.android.ts
+++ b/packages/social-share/index.android.ts
@@ -19,7 +19,7 @@ function useAndroidX() {
 	return global.androidx && global.androidx.appcompat;
 }
 
-export function shareImage(image, subject) {
+export function shareImage(image, subject, caption) {
 	numberOfImagesCreated++;
 
 	const intent = getIntent('image/jpeg');
@@ -45,6 +45,10 @@ export function shareImage(image, subject) {
 	}
 	intent.putExtra(android.content.Intent.EXTRA_STREAM, shareableFileUri);
 
+	if (typeof caption === 'string') {
+		intent.putExtra(android.content.Intent.EXTRA_TEXT, caption);
+	}
+
 	share(intent, subject);
 }
 
@@ -55,7 +59,7 @@ export function shareText(text, subject) {
 	share(intent, subject);
 }
 
-export function sharePdf(pdf: File, subject?: string) {
+export function sharePdf(pdf: File, subject?: string, caption?: string) {
 	const intent = getIntent('application/pdf');
 	const fileName = pdf.name;
 	const newFile = new java.io.File((<android.content.Context>Utils.android.getApplicationContext()).getExternalFilesDir(null), fileName);
@@ -75,6 +79,10 @@ export function sharePdf(pdf: File, subject?: string) {
 	}
 
 	intent.putExtra(android.content.Intent.EXTRA_STREAM, shareableFileUri);
+
+	if (typeof caption === 'string') {
+		intent.putExtra(android.content.Intent.EXTRA_TEXT, caption);
+	}
 
 	share(intent, subject);
 }

--- a/packages/social-share/index.d.ts
+++ b/packages/social-share/index.d.ts
@@ -6,7 +6,7 @@ import { File, ImageSource } from '@nativescript/core';
  * @param {string} [subject] - The subject of the share *** ANDROID ONLY ***
  * @param {string} [caption] - Caption to share alongside the image
  */
-export function shareImage(image?: ImageSource, subject?: string, caption?: stirng);
+export function shareImage(image?: ImageSource, subject?: string, caption?: string);
 
 /**
  * Share text.
@@ -21,7 +21,7 @@ export function shareText(text: string, subject?: string);
  * @param {string} [subject] - The subject of the share *** ANDROID ONLY ***
  * @param {string} [caption] - Caption to share alongside the file
  */
-export function sharePdf(pdf: File, subject?: string, caption?: stirng);
+export function sharePdf(pdf: File, subject?: string, caption?: string);
 
 /**
  * Share URL.

--- a/packages/social-share/index.d.ts
+++ b/packages/social-share/index.d.ts
@@ -4,8 +4,9 @@ import { File, ImageSource } from '@nativescript/core';
  * Share an image.
  * @param {ImageSource} image - The image to share.
  * @param {string} [subject] - The subject of the share *** ANDROID ONLY ***
+ * @param {string} [caption] - Caption to share alongside the image
  */
-export function shareImage(image?: ImageSource, subject?: string);
+export function shareImage(image?: ImageSource, subject?: string, caption?: stirng);
 
 /**
  * Share text.
@@ -18,8 +19,9 @@ export function shareText(text: string, subject?: string);
  * Share a PDF document.
  * @param {File} pdf - PDF file to share.
  * @param {string} [subject] - The subject of the share *** ANDROID ONLY ***
+ * @param {string} [caption] - Caption to share alongside the file
  */
-export function sharePdf(pdf: File, subject?: string);
+export function sharePdf(pdf: File, subject?: string, caption?: stirng);
 
 /**
  * Share URL.

--- a/packages/social-share/index.ios.ts
+++ b/packages/social-share/index.ios.ts
@@ -48,16 +48,24 @@ function getRootViewController() {
 	return win.rootViewController;
 }
 
-export function shareImage(image: ImageSource) {
-	share([image.ios]);
+export function shareImage(image: ImageSource, subject?: string, caption?: string) {
+	if (typeof caption === 'string') {
+		share([image.ios, caption]);
+	} else {
+		share([image.ios]);
+	}
 }
 
 export function shareText(text: string) {
 	share([text]);
 }
 
-export function sharePdf(pdf: File) {
-	share([NSURL.fileURLWithPath(pdf.path)]);
+export function sharePdf(pdf: File, subject?: string, caption?: string) {
+	if (typeof caption === 'string') {
+		share([NSURL.fileURLWithPath(pdf.path), caption]);
+	} else {
+		share([NSURL.fileURLWithPath(pdf.path)]);
+	}
 }
 
 export function shareUrl(url, text) {


### PR DESCRIPTION
This PR adds support for sharing an optional caption alongside images and PDFs on Android and iOS.