### PR TITLE
fix(google-maps): Marker image documentation

### DIFF
--- a/packages/google-maps/README.md
+++ b/packages/google-maps/README.md
@@ -411,7 +411,7 @@ function addMarker(map: GoogleMap, markerOptions: MarkerOptions): Marker {
 | `opacity` | number | Opacity of the marker.
 | `title` | string | A string that's displayed in the info window when the user taps the marker
 | `snippet` | string | Additional text that's displayed below the title
-| `icon` | Image | A image that's displayed in place of the default marker image
+| `icon` | ImageSource \| UIImage \| Bitmap | A image that's displayed in place of the default marker image
 | `draggable` | boolean | Set to `true` if you want to allow the user to move the marker. Defaults to `false`
 | `flat` | boolean | By default, markers are oriented against the screen, and will not rotate or tilt with the camera. Flat markers are oriented against the surface of the earth, and will rotate and tilt with the camera
 | `rotation` | boolean | The orientation of the marker, specified in degrees clockwise

--- a/packages/google-maps/index.d.ts
+++ b/packages/google-maps/index.d.ts
@@ -290,7 +290,7 @@ export interface IMarker {
 	position: Coordinate;
 	title: string;
 	snippet: string;
-	icon: any /* Image, ImageSource, UIImage & Bitmap */;
+	icon: any /* ImageSource, UIImage & Bitmap */;
 	color: Color | string;
 	opacity: number;
 	rotation: number;


### PR DESCRIPTION
Quick PR to help reduce future confusion around custom marker icons.

Current types have `Image` in the comment, however we're type checking for either a platform native image or an ImageSource.
https://github.com/NativeScript/plugins/blob/main/packages/google-maps/index.android.ts#L1136
