### PR TITLE
ref(geolocation): Updated plugin to use latest google API for android

### DIFF
--- a/packages/geolocation/index.android.ts
+++ b/packages/geolocation/index.android.ts
@@ -107,9 +107,11 @@ function _getLocationRequest(options: Options): any {
 	const minUpdateIntervalMillis = options?.minimumUpdateTime ?? Math.min(updateIntervalMillis, fastestTimeUpdate);
 	const minUpdateDistance = options?.updateDistance ?? 0;
 
-	const mLocationRequest = new com.google.android.gms.location.LocationRequest.Builder(priority, updateIntervalMillis).setMinUpdateIntervalMillis(minUpdateIntervalMillis).setMinUpdateDistanceMeters(minUpdateDistance).build();
+	const mLocationRequestBuilder = new com.google.android.gms.location.LocationRequest.Builder(priority, updateIntervalMillis);
+	mLocationRequestBuilder.setMinUpdateIntervalMillis(minUpdateIntervalMillis);
+	mLocationRequestBuilder.setMinUpdateDistanceMeters(minUpdateDistance);
 
-	return mLocationRequest;
+	return mLocationRequestBuilder.build();
 }
 
 function _requestLocationPermissions(always: boolean): Promise<void> {

--- a/packages/geolocation/index.android.ts
+++ b/packages/geolocation/index.android.ts
@@ -105,11 +105,13 @@ function _getLocationRequest(options: Options): any {
 	const priority = com.google.android.gms.location.Priority[options?.desiredAccuracy === CoreTypes.Accuracy.high ? 'PRIORITY_HIGH_ACCURACY' : 'PRIORITY_BALANCED_POWER_ACCURACY'];
 	const updateIntervalMillis = options?.updateTime ?? minTimeUpdate;
 	const minUpdateIntervalMillis = options?.minimumUpdateTime ?? Math.min(updateIntervalMillis, fastestTimeUpdate);
-	const minUpdateDistance = options?.updateDistance ?? 0;
+	const minUpdateDistanceMeters = options?.updateDistance;
 
 	const mLocationRequestBuilder = new com.google.android.gms.location.LocationRequest.Builder(priority, updateIntervalMillis);
 	mLocationRequestBuilder.setMinUpdateIntervalMillis(minUpdateIntervalMillis);
-	mLocationRequestBuilder.setMinUpdateDistanceMeters(minUpdateDistance);
+	if (minUpdateDistanceMeters) {
+		mLocationRequestBuilder.setMinUpdateDistanceMeters(minUpdateDistanceMeters);
+	}
 
 	return mLocationRequestBuilder.build();
 }

--- a/packages/geolocation/index.android.ts
+++ b/packages/geolocation/index.android.ts
@@ -1,4 +1,4 @@
-import { Application, CoreTypes, UnhandledErrorEventData, AndroidApplication, Device, ApplicationSettings } from '@nativescript/core';
+import { Application, CoreTypes, UnhandledErrorEventData, AndroidApplication, Device, ApplicationSettings, Utils } from '@nativescript/core';
 import { LocationBase, defaultGetLocationTimeout, fastestTimeUpdate, minTimeUpdate } from './common';
 import { Options, successCallbackType, errorCallbackType, permissionCallbackType } from '.';
 import * as permissions from 'nativescript-permissions';
@@ -16,7 +16,7 @@ let attachedForErrorHandling = false;
 
 function _ensureLocationClient() {
 	// Wrapped in a function as we should not access java object there because of the snapshots.
-	fusedLocationClient = fusedLocationClient || com.google.android.gms.location.LocationServices.getFusedLocationProviderClient(Application.android.context);
+	fusedLocationClient = fusedLocationClient || com.google.android.gms.location.LocationServices.getFusedLocationProviderClient(Utils.android.getApplicationContext());
 }
 
 Application.android.on(AndroidApplication.activityResultEvent, function (args: any) {
@@ -37,7 +37,7 @@ function isAirplaneModeOn(): boolean {
 
 function isProviderEnabled(provider: string): boolean {
 	try {
-		const locationManager: android.location.LocationManager = (<android.content.Context>Application.android.context).getSystemService(android.content.Context.LOCATION_SERVICE);
+		const locationManager: android.location.LocationManager = (<android.content.Context>Utils.android.getApplicationContext()).getSystemService(android.content.Context.LOCATION_SERVICE);
 		return locationManager.isProviderEnabled(provider);
 	} catch (ex) {
 		return false;
@@ -270,7 +270,7 @@ function _isGooglePlayServicesAvailable(): boolean {
 
 	let isLocationServiceEnabled = true;
 	const googleApiAvailability = com.google.android.gms.common.GoogleApiAvailability.getInstance();
-	const resultCode = googleApiAvailability.isGooglePlayServicesAvailable(Application.android.context);
+	const resultCode = googleApiAvailability.isGooglePlayServicesAvailable(Utils.android.getApplicationContext());
 	if (resultCode !== com.google.android.gms.common.ConnectionResult.SUCCESS) {
 		isLocationServiceEnabled = false;
 	}
@@ -290,13 +290,13 @@ function _isLocationServiceEnabled(options?: Options): Promise<boolean> {
 		const locationSettingsBuilder = new com.google.android.gms.location.LocationSettingsRequest.Builder();
 		locationSettingsBuilder.addLocationRequest(locationRequest);
 		locationSettingsBuilder.setAlwaysShow(true);
-		const locationSettingsClient = com.google.android.gms.location.LocationServices.getSettingsClient(Application.android.context);
+		const locationSettingsClient = com.google.android.gms.location.LocationServices.getSettingsClient(Utils.android.getApplicationContext());
 		locationSettingsClient.checkLocationSettings(locationSettingsBuilder.build()).addOnSuccessListener(_getTaskSuccessListener(resolve)).addOnFailureListener(_getTaskFailListener(reject));
 	});
 }
 
 function _goToPhoneSettings() {
-	const intent = new android.content.Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS, android.net.Uri.fromParts('package', Application.android.context.getPackageName(), null));
+	const intent = new android.content.Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS, android.net.Uri.fromParts('package', Utils.android.getApplicationContext().getPackageName(), null));
 	const activity = Application.android.foregroundActivity || Application.android.startActivity;
 	intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK);
 	activity.startActivity(intent);

--- a/packages/geolocation/index.ios.ts
+++ b/packages/geolocation/index.ios.ts
@@ -1,4 +1,4 @@
-import { Application, Enums, UnhandledErrorEventData, Device, ApplicationSettings } from '@nativescript/core';
+import { Application, CoreTypes, UnhandledErrorEventData, Device, ApplicationSettings } from '@nativescript/core';
 import { LocationBase, defaultGetLocationTimeout, minRangeUpdate } from './common';
 import { Options, successCallbackType, errorCallbackType, permissionCallbackType } from '.';
 export * from './common';
@@ -200,7 +200,7 @@ export function getCurrentLocation(options?: Options): Promise<Location> {
 							return;
 						}
 
-						if (options.desiredAccuracy !== Enums.Accuracy.any && !initLocation) {
+						if (options.desiredAccuracy !== CoreTypes.Accuracy.any && !initLocation) {
 							// regardless of desired accuracy ios returns first location as quick as possible even if not as accurate as requested
 							initLocation = location;
 							return;
@@ -401,7 +401,7 @@ export class LocationMonitor {
 	static createiOSLocationManager(locListener: any, options?: Options): CLLocationManager {
 		const iosLocManager = new CLLocationManager();
 		iosLocManager.delegate = locListener;
-		iosLocManager.desiredAccuracy = options?.desiredAccuracy ?? Enums.Accuracy.high;
+		iosLocManager.desiredAccuracy = options?.desiredAccuracy ?? CoreTypes.Accuracy.high;
 		iosLocManager.distanceFilter = options?.updateDistance ?? minRangeUpdate;
 		locationManagers[locListener.id] = iosLocManager;
 		locationListeners[locListener.id] = locListener;
@@ -422,7 +422,7 @@ function getIOSLocationManager(locListener: any, options?: Options): CLLocationM
 		const manager = new iosLocationManager();
 
 		manager.delegate = locListener;
-		manager.desiredAccuracy = options?.desiredAccuracy ?? Enums.Accuracy.high;
+		manager.desiredAccuracy = options?.desiredAccuracy ?? CoreTypes.Accuracy.high;
 		manager.distanceFilter = options?.updateDistance ?? minRangeUpdate;
 
 		locationManagers[locListener.id] = manager;

--- a/packages/geolocation/platforms/android/include.gradle
+++ b/packages/geolocation/platforms/android/include.gradle
@@ -11,6 +11,6 @@ android {
 }
 
 dependencies {
-	def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "11.4.0"
+	def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "+"
 	implementation "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
This patch updates `geolocation` plugin to be compatible with latest API of `com.google.android.gms:play-services-location`.

It should also fix some problems that occur when plugin is used along with google maps plugin.
See: https://discord.com/channels/603595811204366337/751068755206864916/1040973284793135176