### PR TITLE
fix(imagepicker): android add support for API 33+

### DIFF
--- a/packages/imagepicker/README.md
+++ b/packages/imagepicker/README.md
@@ -22,13 +22,13 @@ In short here are the steps:
 
 _TypeScript_
 
-```
+```ts
 import * as imagepicker from "@nativescript/imagepicker";
 ```
 
 _Javascript_
 
-```
+```js
 var imagepicker = require("@nativescript/imagepicker");
 ```
 
@@ -38,7 +38,7 @@ Create imagepicker in `single` or `multiple` mode to specifiy if the imagepicker
 
 _TypeScript_
 
-```
+```ts
 let context = imagepicker.create({
     mode: "single" // use "multiple" for multiple selection
 });
@@ -46,13 +46,13 @@ let context = imagepicker.create({
 
 _Javascript_
 
-```
+```js
 var context = imagepicker.create({ mode: "single" }); // use "multiple" for multiple selection
 ```
 
 ### Request permissions, show the images list and process the selection
 
-```
+```ts
 context
     .authorize()
     .then(function() {
@@ -70,13 +70,25 @@ context
 
 > **NOTE**: To request permissions for Android 6+ (API 23+) we use [nativescript-permissions](https://www.npmjs.com/package/nativescript-permissions).
 
-> **NOTE**: To be sure to have permissions add the following lines in AndroidManifest.xml
+> **NOTE**: Apps with a targetSdkVersion <33 To be sure to have permissions add the following lines in AndroidManifest.xml
 
-```
+```xml
 <manifest ... >
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
   <application android:requestLegacyExternalStorage="true" ... >
+    ...
+  </application>
+</manifest>
+```
+
+> **NOTE**:  Apps with a targetSdkVersion >=33 i.e. Android 13+ (API 33+): To be sure to have permissions add the following lines in AndroidManifest.xml
+
+```xml
+<manifest ... >
+    ...
+ 	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     ...
   </application>
 </manifest>

--- a/packages/imagepicker/index.android.ts
+++ b/packages/imagepicker/index.android.ts
@@ -1,4 +1,4 @@
-import { ImageAsset, Application, AndroidApplication } from '@nativescript/core';
+import { ImageAsset, Application, AndroidApplication, Utils } from '@nativescript/core';
 import * as permissions from 'nativescript-permissions';
 
 import { ImagePickerMediaType, Options } from './common';
@@ -171,7 +171,21 @@ export class ImagePicker {
 	}
 
 	authorize(): Promise<void> {
-		if ((<any>android).os.Build.VERSION.SDK_INT >= 23) {
+		if ((<any>android).os.Build.VERSION.SDK_INT >= 33 && Utils.ad.getApplicationContext().getApplicationInfo().targetSdkVersion >= 33) {
+			console.log('In api 33');
+			const requested = [];
+			if (this.mediaType === 'image/*') {
+				requested.push((<any>android).Manifest.permission.READ_MEDIA_IMAGES);
+			} else if (this.mediaType === 'video/*') {
+				requested.push((<any>android).Manifest.permission.READ_MEDIA_VIDEO);
+			} else {
+				requested.push((<any>android).Manifest.permission.READ_MEDIA_IMAGES);
+				requested.push((<any>android).Manifest.permission.READ_MEDIA_VIDEO);
+			}
+
+			return permissions.requestPermission(requested);
+		} else if ((<any>android).os.Build.VERSION.SDK_INT >= 23) {
+			console.log('in api 23');
 			return permissions.requestPermission([(<any>android).Manifest.permission.READ_EXTERNAL_STORAGE]);
 		} else {
 			return Promise.resolve();

--- a/packages/imagepicker/index.android.ts
+++ b/packages/imagepicker/index.android.ts
@@ -172,7 +172,6 @@ export class ImagePicker {
 
 	authorize(): Promise<void> {
 		if ((<any>android).os.Build.VERSION.SDK_INT >= 33 && Utils.ad.getApplicationContext().getApplicationInfo().targetSdkVersion >= 33) {
-			console.log('In api 33');
 			const requested = [];
 			if (this.mediaType === 'image/*') {
 				requested.push((<any>android).Manifest.permission.READ_MEDIA_IMAGES);
@@ -185,7 +184,6 @@ export class ImagePicker {
 
 			return permissions.requestPermission(requested);
 		} else if ((<any>android).os.Build.VERSION.SDK_INT >= 23) {
-			console.log('in api 23');
 			return permissions.requestPermission([(<any>android).Manifest.permission.READ_EXTERNAL_STORAGE]);
 		} else {
 			return Promise.resolve();

--- a/packages/imagepicker/package.json
+++ b/packages/imagepicker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nativescript/imagepicker",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "A plugin for the NativeScript framework implementing multiple image picker",
 	"main": "index",
 	"typings": "index.d.ts",

--- a/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
@@ -20,6 +20,8 @@
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<uses-permission android:name="android.permission.WRITE_CONTACTS" />
 	<uses-permission android:name="android.permission.GLOBAL_SEARCH" />
+	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
 	<application
 		android:name="com.tns.NativeScriptApplication"

--- a/tools/scripts/before-prepare.js
+++ b/tools/scripts/before-prepare.js
@@ -44,7 +44,7 @@ module.exports = function (hookArgs, $logger, $projectData) {
 			};
 			const portalFolderPath = path.join(resourcesPath, ionicPortalName);
 			if (!fs.existsSync(portalFolderPath)) {
-				fs.mkdirSync(portalFolderPath);
+				fs.mkdirSync(portalFolderPath, { recursive: true });
 			}
 			const contents = fs.readdirSync(configAppResourcesPath);
 			copyRecursive(contents);


### PR DESCRIPTION
Add support for new android API 33 permissions for imagepicker.

Currently for an app with targetSDK=33 the imagepicker will not get the correct permissions, this resolves that. 