### PR TITLE
[Picker] Fix android item height not being considered and add showPicker

### DIFF
--- a/apps/demo/src/plugin-demos/picker.ts
+++ b/apps/demo/src/plugin-demos/picker.ts
@@ -13,4 +13,16 @@ export function showPicker(args: EventData) {
 	const view: View = args.object as View;
 	const picker: PickerField = view.page.getViewById('picker');
 	picker.showPicker();
+
+	/*
+    setTimeout(() => {
+        closePicker(args)
+    }, 3000)
+    */
+}
+
+function closePicker(args: EventData) {
+	const view: View = args.object as View;
+	const picker: PickerField = view.page.getViewById('picker');
+	picker.closePicker();
 }

--- a/apps/demo/src/plugin-demos/picker.ts
+++ b/apps/demo/src/plugin-demos/picker.ts
@@ -1,6 +1,6 @@
-import { Observable, EventData, Page } from '@nativescript/core';
+import { Observable, EventData, Page, View } from '@nativescript/core';
 import { DemoSharedPicker } from '@demo/shared';
-import {} from '@nativescript/picker';
+import { PickerField } from '@nativescript/picker';
 
 export function navigatingTo(args: EventData) {
 	const page = <Page>args.object;
@@ -8,3 +8,9 @@ export function navigatingTo(args: EventData) {
 }
 
 export class DemoModel extends DemoSharedPicker {}
+
+export function showPicker(args: EventData) {
+	const view: View = args.object as View;
+	const picker: PickerField = view.page.getViewById('picker');
+	picker.showPicker();
+}

--- a/apps/demo/src/plugin-demos/picker.xml
+++ b/apps/demo/src/plugin-demos/picker.xml
@@ -6,9 +6,17 @@
     <StackLayout class="p-20">
         <ScrollView class="h-full">
           <StackLayout>
-              <picker:PickerField hint="Click here" padding="10" pickerOpened="{{ pickerOpened }}" pickerClosed="{{ pickerClosed }}"
+
+            <Button text="Show Picker Programatically" tap="showPicker" />
+            <picker:PickerField rowHeight="300" id="picker" hint="Click here" textField="name" padding="10" pickerOpened="{{ pickerOpened }}" pickerClosed="{{ pickerClosed }}"
   								items="{{ pickerItems }}" >
-  		</picker:PickerField>
+                <picker:PickerField.itemTemplate>
+                    <GridLayout height="300">
+                        <Label text="{{ name}}" textWrap="true" />
+                        
+                    </GridLayout>
+                </picker:PickerField.itemTemplate>
+  		    </picker:PickerField>
 
           </StackLayout>
         </ScrollView>

--- a/packages/picker/common.ts
+++ b/packages/picker/common.ts
@@ -210,12 +210,12 @@ export class PickerField extends TextField implements TemplatedItemsView {
 		return undefined;
 	}
 
-	public static modalAnimatedProperty = new Property<PickerField, boolean>({
+	public static rowHeightProperty = new Property<PickerField, string>({
 		name: 'rowHeight',
 		valueChanged: PickerField.rowHeightChanged,
 	});
 
-	public static rowHeightProperty = new Property<PickerField, boolean>({
+	public static modalAnimatedProperty = new Property<PickerField, boolean>({
 		name: 'modalAnimated',
 		defaultValue: true,
 		valueConverter: booleanConverter,

--- a/packages/picker/common.ts
+++ b/packages/picker/common.ts
@@ -1,4 +1,4 @@
-import { Observable, Property, Template, booleanConverter, CSSType, View, EventData, TextField, Button, GestureEventData, ListView, ItemEventData, TemplatedItemsView, Page, ShownModallyData, fromObject, addWeakEventListener, removeWeakEventListener, ObservableArray, ChangedData, GridLayout, ActionItem, NavigationButton, Frame, ShowModalOptions, Builder } from '@nativescript/core';
+import { Observable, Length, Property, Template, booleanConverter, CSSType, View, EventData, TextField, Button, GestureEventData, ListView, ItemEventData, TemplatedItemsView, Page, ShownModallyData, fromObject, addWeakEventListener, removeWeakEventListener, ObservableArray, ChangedData, GridLayout, ActionItem, NavigationButton, Frame, ShowModalOptions, Builder } from '@nativescript/core';
 
 export interface ItemsSource {
 	length: number;
@@ -19,7 +19,6 @@ export class PickerPage extends Page {}
 @CSSType('PickerField')
 export class PickerField extends TextField implements TemplatedItemsView {
 	public static itemLoadingEvent = 'itemLoading';
-
 	public pickerTitle: string;
 	public items: any[] | ItemsSource;
 	public itemTemplate: string | Template;
@@ -40,6 +39,7 @@ export class PickerField extends TextField implements TemplatedItemsView {
 	private _page: Page;
 	private _modalGridLayout: GridLayout;
 	private closeCallback;
+	private rowHeight: string;
 
 	constructor() {
 		super();
@@ -135,6 +135,10 @@ export class PickerField extends TextField implements TemplatedItemsView {
 		}
 	}
 
+	public showPicker(args) {
+		this.tapHandler(args);
+	}
+
 	private detachModalViewHandlers() {
 		this._modalRoot.off(Page.shownModallyEvent, this.shownModallyHandler.bind(this));
 		this._modalListView.off(ListView.itemTapEvent, this.listViewItemTapHandler.bind(this));
@@ -207,6 +211,11 @@ export class PickerField extends TextField implements TemplatedItemsView {
 	}
 
 	public static modalAnimatedProperty = new Property<PickerField, boolean>({
+		name: 'rowHeight',
+		valueChanged: PickerField.rowHeightChanged,
+	});
+
+	public static rowHeightProperty = new Property<PickerField, boolean>({
 		name: 'modalAnimated',
 		defaultValue: true,
 		valueConverter: booleanConverter,
@@ -215,6 +224,11 @@ export class PickerField extends TextField implements TemplatedItemsView {
 
 	private static modalAnimatedChanged(target: PickerField, oldValue, newValue) {
 		target.onModalAnimatedPropertyChanged(oldValue, newValue);
+	}
+
+	static rowHeightChanged(target, oldValue, newValue) {
+		console.error(target, oldValue, newValue);
+		target.onRowHeightPropertyChanged(oldValue, newValue);
 	}
 
 	public static selectedValueProperty = new Property<PickerField, any>({
@@ -350,6 +364,10 @@ export class PickerField extends TextField implements TemplatedItemsView {
 		this.onValueFieldChanged(oldValue, newValue);
 	}
 
+	private onRowHeightPropertyChanged(oldValue, newValue) {
+		this.rowHeight = newValue;
+	}
+
 	private onTextFieldPropertyChanged(oldValue: string, newValue: string) {
 		this.onTextFieldChanged(oldValue, newValue);
 	}
@@ -394,6 +412,7 @@ export class PickerField extends TextField implements TemplatedItemsView {
 	private updateListView() {
 		if (this._modalListView && this.itemTemplate) {
 			this._modalListView.itemTemplate = this.itemTemplate;
+			this._modalListView.rowHeight = Length.parse(this.rowHeight);
 			this._modalListView.refresh();
 		}
 	}
@@ -509,6 +528,7 @@ export class PickerField extends TextField implements TemplatedItemsView {
 }
 
 PickerField.modalAnimatedProperty.register(PickerField);
+PickerField.rowHeightProperty.register(PickerField);
 PickerField.pickerTitleProperty.register(PickerField);
 PickerField.itemTemplateProperty.register(PickerField);
 PickerField.editableProperty.register(PickerField);

--- a/packages/picker/common.ts
+++ b/packages/picker/common.ts
@@ -135,8 +135,12 @@ export class PickerField extends TextField implements TemplatedItemsView {
 		}
 	}
 
-	public showPicker(args) {
+	public showPicker(args: GestureEventData) {
 		this.tapHandler(args);
+	}
+
+	public closePicker(args: EventData) {
+		this._modalRoot.closeModal(this.closeCallback);
 	}
 
 	private detachModalViewHandlers() {

--- a/packages/picker/index.d.ts
+++ b/packages/picker/index.d.ts
@@ -20,6 +20,16 @@ export class PickerField extends TextField implements TemplatedItemsView {
 	public static itemLoadingEvent: string;
 
 	/**
+	 * Show picker programatically
+	 */
+	public showPicker: Function;
+
+	/**
+	 * Set the `rowHeight` to the Listview
+	 */
+	public static rowHeight: string;
+
+	/**
 	 * Gets or sets the title of the modal view.
 	 */
 	public pickerTitle: string;
@@ -90,6 +100,11 @@ export class PickerField extends TextField implements TemplatedItemsView {
 	 * Identifies the {@link textField} dependency property.
 	 */
 	static textFieldProperty: Property<PickerField, string>;
+
+	/**
+	 * Identifies the {@link rowHeight} dependency property.
+	 */
+	static rowHeightProperty: Property<PickerField, string>;
 
 	/**
 	 * Identifies the {@link iOSCloseButtonPosition} dependency property.

--- a/packages/picker/index.d.ts
+++ b/packages/picker/index.d.ts
@@ -25,6 +25,11 @@ export class PickerField extends TextField implements TemplatedItemsView {
 	public showPicker: Function;
 
 	/**
+	 * Close picker programatically
+	 */
+	public closePicker: Function;
+
+	/**
 	 * Set the `rowHeight` to the Listview
 	 */
 	public static rowHeight: string;

--- a/tools/demo/picker/index.ts
+++ b/tools/demo/picker/index.ts
@@ -30,7 +30,9 @@ export class DemoSharedPicker extends DemoSharedBase {
 		let array = new ObservableArray<string>();
 
 		for (let i = 0; i < size; i++) {
-			array.push('Item ' + i);
+			array.push({
+				name: 'Item ' + i,
+			});
 		}
 
 		return array;


### PR DESCRIPTION
Hi @NathanWalker 

I Fixed the android doesn't update the item height in any way ! I have exposed the rowHeight property of the Listview to control the item height.

And I have exposed the `showPicker` function to open the picker programatically.