### PR TITLE
fix(google-maps/ios): update version for compatibility with m1

### DIFF
--- a/packages/google-maps/platforms/ios/Podfile
+++ b/packages/google-maps/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'GoogleMaps', '6.2.1'
+pod 'GoogleMaps', '7.3.0'


### PR DESCRIPTION
I have updated the version for compatibility with apple m1/2 processors. I have tested it in my application and it works perfect. I have also looked at the changes in versions and it does not seem that there could be any breaking change

https://developers.google.com/maps/documentation/ios-sdk/release-notes