### PR TITLE
fix(@nativescript/haptics): Fixed Android Manifest

### DIFF
--- a/packages/haptics/platforms/android/AndroidManifest.xml
+++ b/packages/haptics/platforms/android/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
-	<uses-permission android:name="android.permission.VIBRATE"></uses-permission>
+	<uses-permission android:name="android.permission.VIBRATE"/>
 </manifest>


### PR DESCRIPTION
**@nativescript/haptics** was not adding automatically the right permissions when building the app for Android. I believe it was due to this error, since I modified it locally and now my app vibrates.

If the developer is responsible for adding this permission, then it should be stated in the docs 😄 