### PR TITLE
feat(facebook): update facebook android sdk to 16.0.0

### DIFF
--- a/packages/facebook/platforms/android/include.gradle
+++ b/packages/facebook/platforms/android/include.gradle
@@ -1,8 +1,8 @@
 repositories {
-    mavenCentral() 
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'com.facebook.android:facebook-core:14.1.0'
-    implementation 'com.facebook.android:facebook-login:14.1.0'
+    implementation 'com.facebook.android:facebook-core:16.0.0'
+    implementation 'com.facebook.android:facebook-login:16.0.0'
 }


### PR DESCRIPTION
This upgrade fixes https://github.com/NativeScript/plugins/issues/465.
Actually an upgrade from current version 14.1.0 to 14.1.1 would be enough to fix that issue, but I just tried installing latest version 16.0.0 and everything worked so far.