### PR TITLE
feat(google-maps): add tile cache clearing

### DIFF
--- a/packages/google-maps/README.md
+++ b/packages/google-maps/README.md
@@ -682,6 +682,9 @@ function addTileOverlay(map: GoogleMap, tileOverlayOptions: TileOverlayOptions):
 | `visible` | `boolean` |
 | `tileProvider` | [TileProvider](#tile-providers) & Partial\<NativeObject\> |
 | `zIndex` | `number` |
+| `clearTileCache()` | `void` |
+
+Setting tile overlay options after the tile overlay has been added to the map can have no effect on the tile overlay. To update the tile overlay, you may need to call `clearTileCache()`.
 
 #### Removing Tile Overlays
 

--- a/packages/google-maps/index.android.ts
+++ b/packages/google-maps/index.android.ts
@@ -1782,6 +1782,10 @@ export class TileOverlay implements Partial<ITileOverlay> {
 	set zIndex(value) {
 		this.native.setZIndex(value);
 	}
+
+	clearTileCache() {
+		this.native.clearTileCache();
+	}
 }
 
 export class Tile {

--- a/packages/google-maps/index.d.ts
+++ b/packages/google-maps/index.d.ts
@@ -742,6 +742,7 @@ export interface ITileOverlay {
 	visible: boolean;
 	tileProvider: TileProvider & Partial<NativeObject>;
 	zIndex: number;
+	clearTileCache(): void;
 }
 
 export class Tile {

--- a/packages/google-maps/index.ios.ts
+++ b/packages/google-maps/index.ios.ts
@@ -1706,6 +1706,10 @@ export class TileOverlay implements Partial<ITileOverlay> {
 	set zIndex(value) {
 		this.native.zIndex = value;
 	}
+
+	clearTileCache() {
+		this.native.clearTileCache();
+	}
 }
 
 export class Tile {


### PR DESCRIPTION
Adds clearTileCache function to TileOverlays.

Needed to reset the TileOverlay view if changes have been made to the overlay after being added to the map.