### PR TITLE
fix(haptics): Crash on Android API level under 29

### DIFF
--- a/packages/haptics/index.android.ts
+++ b/packages/haptics/index.android.ts
@@ -1,6 +1,6 @@
 export * from './common';
 
-import { Utils } from '@nativescript/core';
+import { Utils, Device } from '@nativescript/core';
 import { HapticImpactType, HapticNotificationType } from './common';
 
 export class Haptics {
@@ -52,7 +52,7 @@ function trigger(
 
 	if (!vibrator) return;
 
-	if (vibrator.hasVibrator()) {
+	if (parseFloat(Device.sdkVersion) >= 29 && vibrator.hasVibrator()) {
 		switch (type) {
 			case 'notification':
 				vibrator.vibrate(android.os.VibrationEffect.createPredefined(android.os.VibrationEffect.EFFECT_TICK));


### PR DESCRIPTION
Haptics will crash Android devices on version 9 because some of the constants used was not added before sdk version 29. Added a sdk version check

Example of constant: https://developer.android.com/reference/android/os/VibrationEffect#EFFECT_CLICK