### PR TITLE
feat(secure-storage): Add Support for Access/Application groups on IOS.

### DIFF
--- a/packages/secure-storage/README.md
+++ b/packages/secure-storage/README.md
@@ -117,6 +117,40 @@ Currently this plugin defaults to using `NSUserDefaults` on **iOS Simulators**. 
 
 If you're running into issues similar to [issue_10](https://github.com/EddyVerbruggen/nativescript-secure-storage/issues/10), consider using the default behaviour again.
 
+## iOS Keychain Access/App Groups
+
+You can share secrets between iOS apps/extensions via Keychain access groups, or App Groups, see [here](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps#) for details.
+
+To setup:
+
+* Add a keychain access group entitlement to your app
+  by adding an entry in the ```app/App_Resources/iOS/<someName>.entitlements``` file.
+
+  e.g.
+  ```xml
+  <key>keychain-access-groups</key>
+  <array>
+    <string>$(AppIdentifierPrefix)com.my.app.sharedgroup</string>
+  </array>
+  ```
+* Then in your app specify the ```accessGroup``` property when getting/setting values.
+  e.g. 
+
+  ```typescript
+  import { SecureStorage } from "nativescript-secure-storage";
+  export class MyComponent {
+    secureStorage = new SecureStorage();
+    // a method that can be called from your view
+    setSecureValue() {
+      this.secureStorage.set({
+        accessGroup:"<TeamID>.com.my.app.sharedgroup",
+        key: 'myKey',
+        value: 'my value'
+      }).then(success => { console.log(success)});
+    }
+  }
+  ```
+
 ## Credits
 * On __iOS__ we're leveraging the KeyChain using the [SAMKeychain](https://github.com/soffes/SAMKeychain) library (on the Simulator `NSUserDefaults`),
 * On __Android__ we're using [Hawk](https://github.com/orhanobut/hawk) library which internally uses [Facebook conceal](https://github.com/facebook/conceal).

--- a/packages/secure-storage/common.ts
+++ b/packages/secure-storage/common.ts
@@ -1,17 +1,20 @@
 import { ApplicationSettings } from '@nativescript/core';
 
 export interface SetOptions {
+	accessGroup?: string;
 	service?: string;
 	key: string;
 	value: string;
 }
 
 export interface GetOptions {
+	accessGroup?: string;
 	service?: string;
 	key: string;
 }
 
 export interface RemoveOptions {
+	accessGroup?: string;
 	service?: string;
 	key: string;
 }

--- a/packages/secure-storage/index.ios.ts
+++ b/packages/secure-storage/index.ios.ts
@@ -43,7 +43,9 @@ export class SecureStorage extends SecureStorageCommon {
 			let query = SAMKeychainQuery.new();
 			query.service = arg.service || SecureStorage.defaultService;
 			query.account = arg.key;
-
+			if (arg.accessGroup) {
+				query.accessGroup = arg.accessGroup;
+			}
 			try {
 				query.fetch();
 				resolve(query.password);
@@ -61,6 +63,9 @@ export class SecureStorage extends SecureStorageCommon {
 		let query = SAMKeychainQuery.new();
 		query.service = arg.service || SecureStorage.defaultService;
 		query.account = arg.key;
+		if (arg.accessGroup) {
+			query.accessGroup = arg.accessGroup;
+		}
 		try {
 			query.fetch();
 			return query.password;
@@ -82,6 +87,9 @@ export class SecureStorage extends SecureStorageCommon {
 			query.service = arg.service || SecureStorage.defaultService;
 			query.account = arg.key;
 			query.password = arg.value;
+			if (arg.accessGroup) {
+				query.accessGroup = arg.accessGroup;
+			}
 			resolve(query.save());
 		});
 	}
@@ -97,6 +105,9 @@ export class SecureStorage extends SecureStorageCommon {
 		query.service = arg.service || SecureStorage.defaultService;
 		query.account = arg.key;
 		query.password = arg.value;
+		if (arg.accessGroup) {
+			query.accessGroup = arg.accessGroup;
+		}
 		return query.save();
 	}
 
@@ -111,6 +122,9 @@ export class SecureStorage extends SecureStorageCommon {
 			let query = SAMKeychainQuery.new();
 			query.service = arg.service || SecureStorage.defaultService;
 			query.account = arg.key;
+			if (arg.accessGroup) {
+				query.accessGroup = arg.accessGroup;
+			}
 			try {
 				resolve(query.deleteItem());
 			} catch (e) {
@@ -128,6 +142,9 @@ export class SecureStorage extends SecureStorageCommon {
 		let query = SAMKeychainQuery.new();
 		query.service = arg.service || SecureStorage.defaultService;
 		query.account = arg.key;
+		if (arg.accessGroup) {
+			query.accessGroup = arg.accessGroup;
+		}
 		try {
 			return query.deleteItem();
 		} catch (e) {

--- a/packages/secure-storage/references.d.ts
+++ b/packages/secure-storage/references.d.ts
@@ -1,1 +1,2 @@
 /// <reference path="../../references.d.ts" />
+/// <reference path="./typings/objc!SAMKeychain.d.ts" />

--- a/packages/secure-storage/typings/objc!SAMKeychain.d.ts
+++ b/packages/secure-storage/typings/objc!SAMKeychain.d.ts
@@ -1,0 +1,99 @@
+declare class SAMKeychain extends NSObject {
+	static accessibilityType(): any;
+
+	static accountsForService(serviceName: string): NSArray<NSDictionary<string, any>>;
+
+	static accountsForServiceError(serviceName: string): NSArray<NSDictionary<string, any>>;
+
+	static allAccounts(): NSArray<NSDictionary<string, any>>;
+
+	static alloc(): SAMKeychain; // inherited from NSObject
+
+	static deletePasswordForServiceAccount(serviceName: string, account: string): boolean;
+
+	static deletePasswordForServiceAccountError(serviceName: string, account: string): boolean;
+
+	static new(): SAMKeychain; // inherited from NSObject
+
+	static passwordDataForServiceAccount(serviceName: string, account: string): NSData;
+
+	static passwordDataForServiceAccountError(serviceName: string, account: string): NSData;
+
+	static passwordForServiceAccount(serviceName: string, account: string): string;
+
+	static passwordForServiceAccountError(serviceName: string, account: string): string;
+
+	static setAccessibilityType(accessibilityType: any): void;
+
+	static setPasswordDataForServiceAccount(password: NSData, serviceName: string, account: string): boolean;
+
+	static setPasswordDataForServiceAccountError(password: NSData, serviceName: string, account: string): boolean;
+
+	static setPasswordForServiceAccount(password: string, serviceName: string, account: string): boolean;
+
+	static setPasswordForServiceAccountError(password: string, serviceName: string, account: string): boolean;
+}
+
+declare const enum SAMKeychainErrorCode {
+	BadArguments = -1001,
+}
+
+declare class SAMKeychainQuery extends NSObject {
+	static alloc(): SAMKeychainQuery; // inherited from NSObject
+
+	static isSynchronizationAvailable(): boolean;
+
+	static new(): SAMKeychainQuery; // inherited from NSObject
+
+	accessGroup: string;
+
+	account: string;
+
+	label: string;
+
+	password: string;
+
+	passwordData: NSData;
+
+	passwordObject: NSCoding;
+
+	service: string;
+
+	synchronizationMode: SAMKeychainQuerySynchronizationMode;
+
+	deleteItem(): boolean;
+
+	fetch(): boolean;
+
+	fetchAll(): NSArray<NSDictionary<string, any>>;
+
+	save(): boolean;
+}
+
+declare const enum SAMKeychainQuerySynchronizationMode {
+	Any = 0,
+
+	No = 1,
+
+	Yes = 2,
+}
+
+declare var SAMKeychainVersionNumber: number;
+
+declare var SAMKeychainVersionString: interop.Reference<number>;
+
+declare var kSAMKeychainAccountKey: string;
+
+declare var kSAMKeychainClassKey: string;
+
+declare var kSAMKeychainCreatedAtKey: string;
+
+declare var kSAMKeychainDescriptionKey: string;
+
+declare var kSAMKeychainErrorDomain: string;
+
+declare var kSAMKeychainLabelKey: string;
+
+declare var kSAMKeychainLastModifiedKey: string;
+
+declare var kSAMKeychainWhereKey: string;


### PR DESCRIPTION
Allow the passing of the access group identifier so that secrets can be shared between apps/widgets etc.