### PR TITLE
Support for language codes with 3 characters

### DIFF
--- a/packages/localize/index.android.ts
+++ b/packages/localize/index.android.ts
@@ -41,9 +41,9 @@ export function androidLaunchEventLocalizationHandler() {
 }
 
 export function overrideLocale(locale: string): boolean {
-	let language_code = locale.substring(0, 2)
+	let language_code = locale.substring(0, 2);
 	if (locale.indexOf('-') < 0 && locale.length == 3) {
-		language_code = locale
+		language_code = locale;
 	}
 	ApplicationSettings.setString('__app__language__', language_code);
 	return true;

--- a/packages/localize/index.android.ts
+++ b/packages/localize/index.android.ts
@@ -41,6 +41,10 @@ export function androidLaunchEventLocalizationHandler() {
 }
 
 export function overrideLocale(locale: string): boolean {
-	ApplicationSettings.setString('__app__language__', locale.substring(0, 2));
+	let language_code = locale.substring(0, 2)
+	if (locale.indexOf('-') < 0 && locale.length == 3) {
+		language_code = locale
+	}
+	ApplicationSettings.setString('__app__language__', language_code);
 	return true;
 }

--- a/packages/localize/index.ios.ts
+++ b/packages/localize/index.ios.ts
@@ -30,7 +30,12 @@ export function androidLaunchEventLocalizationHandler() {
 }
 
 export function overrideLocale(locale: string): boolean {
-	const path = NSBundle.mainBundle.pathForResourceOfType(locale.substring(0, 2), 'lproj');
+	let language_code = locale.substring(0, 2)
+	if (locale.indexOf('-') < 0 && locale.length == 3) {
+		language_code = locale
+	}
+
+	const path = NSBundle.mainBundle.pathForResourceOfType(language_code, 'lproj');
 
 	if (!path) {
 		return false;
@@ -39,7 +44,7 @@ export function overrideLocale(locale: string): boolean {
 	bundle = NSBundle.bundleWithPath(path);
 	NSUserDefaults.standardUserDefaults.setObjectForKey([locale], 'AppleLanguages');
 	NSUserDefaults.standardUserDefaults.synchronize();
-	ApplicationSettings.setString('__app__language__', locale.substring(0, 2));
+	ApplicationSettings.setString('__app__language__', language_code);
 
 	return true;
 }

--- a/packages/localize/index.ios.ts
+++ b/packages/localize/index.ios.ts
@@ -30,9 +30,9 @@ export function androidLaunchEventLocalizationHandler() {
 }
 
 export function overrideLocale(locale: string): boolean {
-	let language_code = locale.substring(0, 2)
+	let language_code = locale.substring(0, 2);
 	if (locale.indexOf('-') < 0 && locale.length == 3) {
-		language_code = locale
+		language_code = locale;
 	}
 
 	const path = NSBundle.mainBundle.pathForResourceOfType(language_code, 'lproj');


### PR DESCRIPTION
### Summary
A very basic implementation that checks if a local is a 3 letter language code.