### PR TITLE
fix(imagepicker): consolidate API / Fix typings

### DIFF
--- a/apps/demo-angular/src/plugin-demos/imagepicker.component.html
+++ b/apps/demo-angular/src/plugin-demos/imagepicker.component.html
@@ -5,7 +5,7 @@
 	<ListView [items]="imageAssets" *ngIf="!isSingleMode">
 		<ng-template let-image="item" let-i="index">
 			<GridLayout columns="auto, *">
-				<Image [width]="thumbSize" [height]="thumbSize" [src]="image" stretch="aspectFill"></Image>
+				<Image [width]="thumbSize" [height]="thumbSize" [src]="image.asset" stretch="aspectFill"></Image>
 				<Label col="1" [text]="'image ' + i"></Label>
 			</GridLayout>
 		</ng-template>

--- a/apps/demo-angular/src/plugin-demos/imagepicker.component.ts
+++ b/apps/demo-angular/src/plugin-demos/imagepicker.component.ts
@@ -1,14 +1,14 @@
 import { Component, NgZone } from '@angular/core';
-import { ImageAsset } from '@nativescript/core';
-import * as imagepicker from '@nativescript/imagepicker';
+import { ImageAsset, ImageSource } from '@nativescript/core';
+import { ImagePicker, create, ImagePickerSelection } from '@nativescript/imagepicker';
 
 @Component({
 	selector: 'demo-imagepicker',
 	templateUrl: 'imagepicker.component.html',
 })
 export class ImagepickerComponent {
-	imageAssets = [];
-	imageSrc: any;
+	imageAssets: ImagePickerSelection[] = [];
+	imageSrc: ImageAsset | ImageSource;
 	isSingleMode: boolean = true;
 	thumbSize: number = 80;
 	previewSize: number = 300;
@@ -18,7 +18,7 @@ export class ImagepickerComponent {
 	public onSelectMultipleTap() {
 		this.isSingleMode = false;
 
-		let context = imagepicker.create({
+		let context = create({
 			mode: 'multiple',
 		});
 		this.startSelection(context);
@@ -27,36 +27,40 @@ export class ImagepickerComponent {
 	public onSelectSingleTap() {
 		this.isSingleMode = true;
 
-		let context = imagepicker.create({
+		let context = create({
 			mode: 'single',
 		});
 		this.startSelection(context);
 	}
 
-	private startSelection(context) {
+	private startSelection(context: ImagePicker) {
 		context
 			.authorize()
-			.then(() => {
+			.then((authResult) => {
 				this._ngZone.run(() => {
 					this.imageAssets = [];
 					this.imageSrc = null;
 				});
-				return context.present();
-			})
-			.then((selection) => {
-				this._ngZone.run(() => {
-					console.log('Selection done: ' + JSON.stringify(selection));
-					this.imageSrc = this.isSingleMode && selection.length > 0 ? selection[0] : null;
+				if (authResult.authorized) {
+					return context.present().then((selection) => {
+						this._ngZone.run(() => {
+							console.log('Selection done: ' + JSON.stringify(selection));
+							this.imageSrc = this.isSingleMode && selection.length > 0 ? selection[0].asset : null;
 
-					// set the images to be loaded from the assets with optimal sizes (optimize memory usage)
-					selection.forEach((el: ImageAsset) => {
-						el.options.width = this.isSingleMode ? this.previewSize : this.thumbSize;
-						el.options.height = this.isSingleMode ? this.previewSize : this.thumbSize;
+							// set the images to be loaded from the assets with optimal sizes (optimize memory usage)
+							selection.forEach((el) => {
+								el.asset.options.width = this.isSingleMode ? this.previewSize : this.thumbSize;
+								el.asset.options.height = this.isSingleMode ? this.previewSize : this.thumbSize;
+							});
+
+							this.imageAssets = selection;
+						});
 					});
-
-					this.imageAssets = selection;
-				});
+				} else {
+					console.log('Unauthorised');
+				}
 			})
+
 			.catch(function (e) {
 				console.log(e);
 			});

--- a/packages/imagepicker/README.md
+++ b/packages/imagepicker/README.md
@@ -29,6 +29,11 @@ Install the plugin by running the following command in the root directory of you
 npm install @nativescript/imagepicker
 ```
 
+**Note: Version 3.0 contains breaking changes.**
+* authorise() now returns a `Promise<AuthorizationResult>` for both android and ios.
+* In the returned result from `present()` each `result[i].thumbnail` is now an ImageSource.
+* `result[i].duration` is not typed correctly as a `number`.
+
 **Note: Version 2.0 contains breaking changes. In order supply more information about your selection, the ImageSource asset is nested in the response so you'll need to update your code to use `result.asset` instead of `result` as your src for your Images.**
 
 ## Android required permissions
@@ -97,22 +102,25 @@ The `present` method resolves with the selected media assets that can you to pro
 ```ts
 imagePickerObj
     .authorize()
-    .then(function() {
-        return imagePickerObj.present();
-    })
-    .then(function(selection) {
-        selection.forEach(function(selected) {
-            this.imageSource = selected.asset;
-            this.type = selected.type;
-            this.filesize = selected.filesize;
-            //etc
-        });
-        list.items = selection;
-    }).catch(function (e) {
+    .then((authResult) => {
+        if(authResult.authorized) {
+            return imagePickerObj.present()
+                .then(function(selection) {
+                    selection.forEach(function(selected) {
+                        this.imageSource = selected.asset;
+                        this.type = selected.type;
+                        this.filesize = selected.filesize;
+                        //etc
+                    });
+                });
+        } else {
+            // process authorization not granted.
+        }
+    })    
+    .catch(function (e) {
         // process error
     });
 ```
-> **Note** To request permissions for Android 6+ (API 23+), use [nativescript-permissions](https://www.npmjs.com/package/nativescript-permissions) plugin.
 
 ### Demo
 You can play with the plugin on StackBlitz at any of the following links:
@@ -131,8 +139,8 @@ The class that provides the media selection API. It offers the following methods
 | Method | Returns | Description
 |:-------|:--------|:-----------
 | `constructor(options: Options)` | `ImagePicker` | Instanciates the ImagePicker class with the optional `options` parameter. See [Options](#options)
-| `authorize()` | `Promise<void>` | Requests the required permissions. Call it before calling `present()`. In case of a failed authorization, consider notifying the user for degraded functionality.
-| `present()` | `Promise<ImageAsset[]>` | Presents the image picker UI.
+| `authorize()` | `Promise<AuthorizationResult>` | Requests the required permissions. Call it before calling `present()`. In case of a failed authorization, consider notifying the user for degraded functionality.  The returned `AuthorizationResult` will have it's `authorized` property to `true` if permission was granted.
+| `present()` | `Promise<ImagePickerSelection[]>` | Presents the image picker UI.
 | `create(options: Options, hostView: View)` | `ImagePicker` | Creates an instance of the ImagePicker class. The `hostView` parameter can be set to the view that hosts the image picker. Intended to be used when opening the picker from a modal page.
 
 ### Options

--- a/packages/imagepicker/README.md
+++ b/packages/imagepicker/README.md
@@ -29,10 +29,10 @@ Install the plugin by running the following command in the root directory of you
 npm install @nativescript/imagepicker
 ```
 
-**Note: Version 3.0 contains breaking changes.**
+**Note: Version 3.0 contains breaking changes:**
 * authorise() now returns a `Promise<AuthorizationResult>` for both android and ios.
-* In the returned result from `present()` each `result[i].thumbnail` is now an ImageSource.
-* `result[i].duration` is not typed correctly as a `number`.
+* In the returned result from `present()` each `result[i].thumbnail` is now an `ImageSource`.
+* `result[i].duration` is now typed correctly as a `number`.
 
 **Note: Version 2.0 contains breaking changes. In order supply more information about your selection, the ImageSource asset is nested in the response so you'll need to update your code to use `result.asset` instead of `result` as your src for your Images.**
 
@@ -139,7 +139,7 @@ The class that provides the media selection API. It offers the following methods
 | Method | Returns | Description
 |:-------|:--------|:-----------
 | `constructor(options: Options)` | `ImagePicker` | Instanciates the ImagePicker class with the optional `options` parameter. See [Options](#options)
-| `authorize()` | `Promise<AuthorizationResult>` | Requests the required permissions. Call it before calling `present()`. In case of a failed authorization, consider notifying the user for degraded functionality.  The returned `AuthorizationResult` will have it's `authorized` property to `true` if permission was granted.
+| `authorize()` | `Promise<AuthorizationResult>` | Requests the required permissions. Call it before calling `present()`. In case of a failed authorization, consider notifying the user for degraded functionality.  The returned `AuthorizationResult` will have it's `authorized` property set to `true` if permission has been granted.
 | `present()` | `Promise<ImagePickerSelection[]>` | Presents the image picker UI.
 | `create(options: Options, hostView: View)` | `ImagePicker` | Creates an instance of the ImagePicker class. The `hostView` parameter can be set to the view that hosts the image picker. Intended to be used when opening the picker from a modal page.
 

--- a/packages/imagepicker/README.md
+++ b/packages/imagepicker/README.md
@@ -30,7 +30,7 @@ npm install @nativescript/imagepicker
 ```
 
 **Note: Version 3.0 contains breaking changes:**
-* authorise() now returns a `Promise<AuthorizationResult>` for both android and ios.
+* authorize() now returns a `Promise<AuthorizationResult>` for both android and ios.
 * In the returned result from `present()` each `result[i].thumbnail` is now an `ImageSource`.
 * `result[i].duration` is now typed correctly as a `number`.
 

--- a/packages/imagepicker/common.ts
+++ b/packages/imagepicker/common.ts
@@ -1,4 +1,5 @@
 import { ImageAsset } from '@nativescript/core';
+import { MultiResult, Result } from '@nativescript-community/perms';
 
 export enum ImagePickerMediaType {
 	Any = 0,
@@ -115,4 +116,23 @@ export interface Options {
 		 */
 		read_external_storage?: string;
 	};
+}
+
+export interface ImagePickerApi {
+	/**
+	 * Call this before 'present' to request any additional permissions that may be necessary.
+	 * In case of failed authorization consider notifying the user for degraded functionality.
+	 */
+	authorize(): Promise<AuthorizationResult>;
+
+	/**
+	 * Present the image picker UI.
+	 * The result will be an array of SelectedAsset instances provided when the promise is fulfilled.
+	 */
+	present(): Promise<ImagePickerSelection[]>;
+}
+
+export interface AuthorizationResult {
+	authorised: boolean;
+	details: MultiResult | Result;
 }

--- a/packages/imagepicker/index.d.ts
+++ b/packages/imagepicker/index.d.ts
@@ -1,13 +1,13 @@
 import { ImageSource, ImageAsset, View } from '@nativescript/core';
-
-export class ImagePicker {
+import { AuthorizationResult, ImagePickerApi } from './common';
+export class ImagePicker implements ImagePickerApi {
 	constructor(options?: Options);
 
 	/**
 	 * Call this before 'present' to request any additional permissions that may be necessary.
 	 * In case of failed authorization consider notifying the user for degraded functionality.
 	 */
-	authorize(): Promise<void>;
+	authorize(): Promise<AuthorizationResult>;
 
 	/**
 	 * Present the image picker UI.

--- a/packages/imagepicker/index.d.ts
+++ b/packages/imagepicker/index.d.ts
@@ -1,4 +1,4 @@
-import { Observable, ImageSource, ImageAsset, View } from '@nativescript/core';
+import { ImageSource, ImageAsset, View } from '@nativescript/core';
 
 export class ImagePicker {
 	constructor(options?: Options);

--- a/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
 		android:xlargeScreens="true"/>
 
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>

--- a/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>

--- a/tools/demo/imagepicker/index.ts
+++ b/tools/demo/imagepicker/index.ts
@@ -85,7 +85,8 @@ export class DemoSharedImagepicker extends DemoSharedBase {
 	private startSelection(context) {
 		context
 			.authorize()
-			.then(() => {
+			.then((authResult) => {
+				console.log(authResult);
 				this.imageAssets = [];
 				this.imageSrc = null;
 				this.selection = null;

--- a/tools/demo/imagepicker/index.ts
+++ b/tools/demo/imagepicker/index.ts
@@ -1,10 +1,10 @@
 import { DemoSharedBase } from '../utils';
 import * as imagepicker from '@nativescript/imagepicker';
-import { ItemEventData, Label } from '@nativescript/core';
+import { ImageAsset, ImageSource, ItemEventData, Label } from '@nativescript/core';
 
 export class DemoSharedImagepicker extends DemoSharedBase {
 	private _selection: any;
-	private _imageSrc: any;
+	private _imageSrc: ImageSource | ImageAsset;
 	private _imageAssets: Array<any>;
 	private _isSingleMode: boolean;
 
@@ -16,11 +16,11 @@ export class DemoSharedImagepicker extends DemoSharedBase {
 		return 300;
 	}
 
-	get imageSrc(): any {
+	get imageSrc(): ImageSource | ImageAsset {
 		return this._imageSrc;
 	}
 
-	set imageSrc(value: any) {
+	set imageSrc(value: ImageSource | ImageAsset) {
 		if (this._imageSrc !== value) {
 			this._imageSrc = value;
 			this.notifyPropertyChange('imageSrc', value);
@@ -82,32 +82,35 @@ export class DemoSharedImagepicker extends DemoSharedBase {
 		this.startSelection(context);
 	}
 
-	private startSelection(context) {
+	private startSelection(context: imagepicker.ImagePicker) {
 		context
 			.authorize()
 			.then((authResult) => {
 				console.log(authResult);
-				this.imageAssets = [];
-				this.imageSrc = null;
-				this.selection = null;
-				return context.present();
-			})
-			.then((selection: imagepicker.ImagePickerSelection[]) => {
-				console.log('Selection done: ', selection);
-				this.imageSrc = this.isSingleMode && selection.length > 0 ? selection[0].asset : null;
-				if (selection[0].thumbnail) {
-					this.imageSrc = selection[0].thumbnail;
+				if (authResult.authorized) {
+					this.imageAssets = [];
+					this.imageSrc = null;
+					this.selection = null;
+					return context.present().then((selection: imagepicker.ImagePickerSelection[]) => {
+						console.log('Selection done: ', selection);
+						this.imageSrc = this.isSingleMode && selection.length > 0 ? selection[0].asset : null;
+						if (selection[0].thumbnail) {
+							this.imageSrc = selection[0].thumbnail;
+						}
+						this.selection = this.isSingleMode && selection.length > 0 ? selection[0] : null;
+
+						// set the images to be loaded from the assets with optimal sizes (optimize memory usage)
+						selection.forEach((element) => {
+							let asset = element.asset;
+							asset.options.width = this.isSingleMode ? this.previewSize : this.thumbSize;
+							asset.options.height = this.isSingleMode ? this.previewSize : this.thumbSize;
+						});
+
+						this.imageAssets = selection;
+					});
+				} else {
+					console.log('UnAuthorized');
 				}
-				this.selection = this.isSingleMode && selection.length > 0 ? selection[0] : null;
-
-				// set the images to be loaded from the assets with optimal sizes (optimize memory usage)
-				selection.forEach((element) => {
-					let asset = element.asset;
-					asset.options.width = this.isSingleMode ? this.previewSize : this.thumbSize;
-					asset.options.height = this.isSingleMode ? this.previewSize : this.thumbSize;
-				});
-
-				this.imageAssets = selection;
 			})
 			.catch(function (e) {
 				console.log('selection error', e);


### PR DESCRIPTION
The IOS and Android APIs have diverged with each other, the `.d.ts` and the docs, this is an attempt to bring them all back into sync.

Changes:

* authorize() now returns a `Promise<AuthorizationResult>` for both android and IOS, where the `authorized` property indicates success, and the `details` property holds the returned value from the call to `@nativescript-community/perms`, previously IOS threw an error on , and android returned the raw response from `@nativescript-community/perms` which came in two different forms depending on android version.

* In the returned result from `present()` each `result[i].thumbnail` is now an `ImageSource`, this was previously a `BitMap` for android / `ImageSource` for IOS.

* `result[i].duration` is now typed correctly as a `number`, previously typed as a string, but was always set with a number. 
* Uses `@nativescript-community/perms` in IOS.