### PR TITLE
Populate the shared instance config

### DIFF
--- a/packages/google-signin/index.ios.ts
+++ b/packages/google-signin/index.ios.ts
@@ -138,6 +138,7 @@ export class GoogleSignin {
 
 			const config = GIDConfiguration.alloc().initWithClientIDServerClientIDHostedDomainOpenIDRealm(clientId, serverClientId, configuration.hostedDomain || null, configuration['openIDRealm'] || null);
 			this._nativeConfig = config;
+			GIDSignIn.sharedInstance.configuration = config;
 			resolve();
 		});
 	}


### PR DESCRIPTION
Not sure how this ever worked? The signin method calls the sharedInstance config, but it's always empty

Even with something this simple, the .json is read and client IDs and stuff are set fine after configure

```
         await GoogleSignin.configure();
	debugger;
	const user = await GoogleSignin.signIn();
	debugger;
```

But when we hit signin the "GIDSignIn.sharedInstance" referenced has a null configuration property.

If I set it explicity in the config then I get the google sign in popup just fine, without that, I just get No active configuration. Make sure GIDClientID is set in Info.plist