### PR TITLE
Really type ImagePickerSelection.duration as number.

### DIFF
--- a/packages/imagepicker/index.d.ts
+++ b/packages/imagepicker/index.d.ts
@@ -56,7 +56,7 @@ export interface ImagePickerSelection {
 	/**
 	 * The duration of the video. Only passed if type is 'video'
 	 */
-	duration?: string;
+	duration?: number;
 
 	/**
 	 * An image to use for the video thumbnail. Only passed if type is 'video'


### PR DESCRIPTION
As stated in the README:

```
Note: Version 3.0 contains breaking changes:
[…]
result[i].duration is now typed correctly as a number.
```