### PR TITLE
Fix animated miss implemented for android

### DIFF
--- a/packages/animated-circle/index.android.ts
+++ b/packages/animated-circle/index.android.ts
@@ -6,7 +6,7 @@ declare const at;
 export const animatedProperty = new Property({
     name: 'animated',
     valueChanged: (target, old, newValue) => {
-        target.animated = newValue;
+        target.updateAnimatedCircle();
     },
     defaultValue: false,
     valueConverter: booleanConverter
@@ -14,7 +14,6 @@ export const animatedProperty = new Property({
 
 export class AnimatedCircle extends AnimatedCircleCommon {
 	private _android: any;
-	private _animated: boolean = false;
 	private _progress = 0;
 	private _animateFrom = 0;
 	private _animationDuration = 1000;
@@ -107,15 +106,6 @@ export class AnimatedCircle extends AnimatedCircleCommon {
 
 	get animationDuration(): number {
 		return this._animationDuration;
-	}
-
-	set animated(value: boolean) {
-		this._animated = Boolean(value);
-		this.updateAnimatedCircle();
-	}
-
-	get animated(): boolean {
-		return this._animated;
 	}
 
 	set maxValue(value: number) {

--- a/packages/animated-circle/index.android.ts
+++ b/packages/animated-circle/index.android.ts
@@ -1,10 +1,20 @@
-import { Color } from '@nativescript/core';
+import { Color, Property, booleanConverter } from '@nativescript/core';
 import { AnimatedCircleCommon, barColorProperty, rimColorProperty, spinBarColorProperty } from './common';
 
 declare const at;
 
+export const animatedProperty = new Property({
+    name: 'animated',
+    valueChanged: (target, old, newValue) => {
+        target.animated = newValue;
+    },
+    defaultValue: false,
+    valueConverter: booleanConverter
+});
+
 export class AnimatedCircle extends AnimatedCircleCommon {
 	private _android: any;
+	private _animated: boolean = false;
 	private _progress = 0;
 	private _animateFrom = 0;
 	private _animationDuration = 1000;
@@ -69,7 +79,12 @@ export class AnimatedCircle extends AnimatedCircleCommon {
 
 	set progress(value: number) {
 		this._progress = value;
-		this.android?.setValueAnimated(this._progress);
+		if(this.animated) {
+			this.android?.setValueAnimated(this._progress);
+		}
+		else {
+			this.android?.setValue(this._progress);
+		}
 	}
 
 	get progress(): number {
@@ -318,3 +333,5 @@ export class AnimatedCircle extends AnimatedCircleCommon {
 		}
 	}
 }
+
+animatedProperty.register(AnimatedCircle);

--- a/packages/animated-circle/index.android.ts
+++ b/packages/animated-circle/index.android.ts
@@ -3,7 +3,7 @@ import { AnimatedCircleCommon, barColorProperty, rimColorProperty, spinBarColorP
 
 declare const at;
 
-export const animatedProperty = new Property({
+export const animatedProperty = new Property<AnimatedCircle, boolean>({
     name: 'animated',
     valueChanged: (target, old, newValue) => {
         target.updateAnimatedCircle();


### PR DESCRIPTION
Hi @NathanWalker,

The `animated` property was miss implemented for android, the circle is animated even if we sat `animated = false` and make the animation restarted for each iteration because of the continuous update of the `progress` property, then the last one is animated but too lately.