### PR TITLE
Update interface for CameraPositionEvent (moving -> move)

### DIFF
--- a/packages/google-maps/index.d.ts
+++ b/packages/google-maps/index.d.ts
@@ -54,7 +54,7 @@ export interface MarkerDragEvent extends EventData {
 
 export interface CameraPositionEvent extends EventData {
 	cameraPosition: CameraPosition;
-	state: 'idle' | 'start' | 'moving';
+	state: 'idle' | 'start' | 'move';
 }
 
 export interface CameraPositionStartEvent extends CameraPositionEvent {


### PR DESCRIPTION
The state in the event is "move" not "moving"