### PR TITLE
fix(imagepicker): Recognise "limited" as an authorising option in iOS

### DIFF
--- a/packages/imagepicker/README.md
+++ b/packages/imagepicker/README.md
@@ -29,7 +29,7 @@ Install the plugin by running the following command in the root directory of you
 npm install @nativescript/imagepicker
 ```
 **Note: Version 3.1 contains breaking changes:**
-* New behavior on iOS when the user selects `Select Photos..` detailed in [iOS Limited permission](#ios-limited-permission).
+* New behavior on iOS when the user selects `Limit AccessLim..` detailed in [iOS Limited permission](#ios-limited-permission).
 
 **Note: Version 3.0 contains breaking changes:**
 * authorize() now returns a `Promise<AuthorizationResult>` for both android and ios.
@@ -72,7 +72,7 @@ Apple App Store might reject your app if you do not describe why you need this p
 
 ### iOS Limited permission
 
-Apple introduced the `PHAuthorizationStatusLimited` permission status with iOS 14, this is where the user specifies that the app can only access specified photos by choosing the `Select Photos..` option in the authorization dialog.
+Apple introduced the `PHAuthorizationStatusLimited` permission status with iOS 14, this is where the user specifies that the app can only access specified photos by choosing the `Limit Access..` option in the authorization dialog.
 
 In this case `authorise()` will return an `AuthorizationResult` where `authorized` will be `true` and the `details` will contain `'limited'`.
 

--- a/packages/imagepicker/README.md
+++ b/packages/imagepicker/README.md
@@ -28,6 +28,8 @@ Install the plugin by running the following command in the root directory of you
 ```cli
 npm install @nativescript/imagepicker
 ```
+**Note: Version 3.1 contains breaking changes:**
+* New behavior on iOS when the user selects `Select Photos..` detailed in [iOS Limited permission](#ios-limited-permission).
 
 **Note: Version 3.0 contains breaking changes:**
 * authorize() now returns a `Promise<AuthorizationResult>` for both android and ios.
@@ -67,6 +69,21 @@ Using the plugin on iOS requires the `NSPhotoLibraryUsageDescription` permission
 <string>Description text goes here</string>
 ```
 Apple App Store might reject your app if you do not describe why you need this permission. The default message `Requires access to photo library.` might not be enough for the App Store reviewers. 
+
+### iOS Limited permission
+
+Apple introduced the `PHAuthorizationStatusLimited` permission status with iOS 14, this is where the user specifies that the app can only access specified photos by choosing the `Select Photos..` option in the authorization dialog.
+
+In this case `authorise()` will return an `AuthorizationResult` where `authorized` will be `true` and the `details` will contain `'limited'`.
+
+Every time the app is launched anew, and the authorize method is called, if the current permission is `limited` the user will be prompted to update the image selection.
+
+To prevent this prompt, add the following values to your `App_Resources/iOS/Info.plist`:
+
+```xml
+<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
+<true/>
+```
 
 ## Pick images
 

--- a/packages/imagepicker/common.ts
+++ b/packages/imagepicker/common.ts
@@ -145,7 +145,7 @@ export abstract class ImagePickerBase implements ImagePickerApi {
 		let authorized = true;
 		if (Array.isArray(result) && result.length == 2) {
 			// is of type Result
-			authorized = result[0] === 'authorized';
+			authorized = result[0] === 'authorized' || result[0] === 'limited';
 		} else {
 			const t = result as MultiResult;
 			requestingPermissions.forEach((permission) => {

--- a/packages/imagepicker/package.json
+++ b/packages/imagepicker/package.json
@@ -33,6 +33,6 @@
 	"readmeFilename": "README.md",
 	"bootstrapper": "@nativescript/plugin-seed",
 	"dependencies": {
-		"@nativescript-community/perms": "^2.3.0"
+		"@nativescript-community/perms": "^2.3.1"
 	}
 }

--- a/tools/assets/App_Resources/iOS/Info.plist
+++ b/tools/assets/App_Resources/iOS/Info.plist
@@ -96,5 +96,7 @@
     <string>NativeScriptPluginsDemo</string>
     <key>GIDClientID</key>
     <string>749673967192-c24phj29u2otpict36e71ocjo2g5i3hs.apps.googleusercontent.com</string>
+    <key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
+    <false/>
   </dict>
 </plist>


### PR DESCRIPTION
Currently if the app is on >= iOS 14 and the user selects the `Limit Access...` option on authorization, the `authorise()` method returns false, This changes it to return true. ( bumps the dep on `@nativescript-community/perms` to recived the proper auth response.

If there are no objections I will release as 3.1 in the morning.