### PR TITLE
fix(imagepicker): correct version of nativescript-community/perms

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"@angular/platform-browser": "^15.0.0",
 		"@angular/platform-browser-dynamic": "^15.0.0",
 		"@angular/router": "^15.0.0",
-		"@nativescript-community/perms": "^2.3.0",
+		"@nativescript-community/perms": "^2.3.1",
 		"@nativescript/angular": "^15.0.0",
 		"@nativescript/core": "~8.5.0",
 		"@nativescript/plugin-tools": "5.1.0",


### PR DESCRIPTION
On build the version of dependencies in the project package.json override the package.json in the plugin dir, but not when running the test app, so ended up with the incorrect version of deps in the published.