### PR TITLE
fix: empty `path` in selected assets  + added `augementAssetsInfo` and `resolveWhenDismissed` options

### DIFF
--- a/packages/imagepicker/index.d.ts
+++ b/packages/imagepicker/index.d.ts
@@ -104,6 +104,11 @@ interface Options {
 	numberOfColumnsInLandscape?: number;
 
 	/**
+	 * Set to false on iOS to disable querying thumbnail/filesize for selected assets
+	 */
+	augmentedAssetsInfo: boolean
+
+	/**
 	 * Set the media type (image/video/any) to pick
 	 */
 	mediaType?: ImagePickerMediaType;

--- a/packages/imagepicker/index.d.ts
+++ b/packages/imagepicker/index.d.ts
@@ -106,7 +106,12 @@ interface Options {
 	/**
 	 * Set to false on iOS to disable querying thumbnail/filesize for selected assets
 	 */
-	augmentedAssetsInfo: boolean
+	augmentedAssetsInfo: boolean;
+
+	/**
+	 * Set to true on iOS to wait for controller to be dismissed before resolving
+	 */
+	resolveWhenDismissed: boolean;
 
 	/**
 	 * Set the media type (image/video/any) to pick

--- a/packages/imagepicker/index.ios.ts
+++ b/packages/imagepicker/index.ios.ts
@@ -9,6 +9,7 @@ type FileMap = {
 const defaultAssetCollectionSubtypes: NSArray<any> = NSArray.arrayWithArray(<any>[PHAssetCollectionSubtype.SmartAlbumRecentlyAdded, PHAssetCollectionSubtype.SmartAlbumUserLibrary, PHAssetCollectionSubtype.AlbumMyPhotoStream, PHAssetCollectionSubtype.SmartAlbumFavorites, PHAssetCollectionSubtype.SmartAlbumPanoramas, PHAssetCollectionSubtype.SmartAlbumBursts, PHAssetCollectionSubtype.AlbumCloudShared, PHAssetCollectionSubtype.SmartAlbumSelfPortraits, PHAssetCollectionSubtype.SmartAlbumScreenshots, PHAssetCollectionSubtype.SmartAlbumLivePhotos]);
 let copyToAppFolder;
 let renameFileTo;
+let augmentedAssetsInfo;
 let fileMap: FileMap = {};
 export class ImagePicker extends ImagePickerBase {
 	_imagePickerController: QBImagePickerController;
@@ -45,6 +46,7 @@ export class ImagePicker extends ImagePickerBase {
 		imagePickerController.prompt = options.prompt || imagePickerController.prompt;
 		copyToAppFolder = options.copyToAppFolder || false;
 		renameFileTo = options.renameFileTo || false;
+		augmentedAssetsInfo = options.augmentedAssetsInfo ?? true;
 		this._imagePickerController = imagePickerController;
 	}
 
@@ -88,7 +90,7 @@ class ImagePickerControllerDelegate extends NSObject implements QBImagePickerCon
 		});
 	}
 
-	qb_imagePickerControllerDidFinishPickingAssets?(imagePickerController: QBImagePickerController, iosAssets: NSArray<any>): void {
+	async qb_imagePickerControllerDidFinishPickingAssets?(imagePickerController: QBImagePickerController, iosAssets: NSArray<any>): void {
 		for (let i = 0; i < iosAssets.count; i++) {
 			const asset = new ImageAsset(iosAssets.objectAtIndex(i));
 			const phAssetImage: PHAsset = (<any>asset)._ios;
@@ -115,62 +117,66 @@ class ImagePickerControllerDelegate extends NSObject implements QBImagePickerCon
 			} else {
 				const imageOptions = new PHContentEditingInputRequestOptions();
 				imageOptions.networkAccessAllowed = true;
-				phAssetImage.requestContentEditingInputWithOptionsCompletionHandler(imageOptions, (thing) => {
-					fileMap[existingFileName].path = thing.fullSizeImageURL.toString().replace('file://', '');
+				await new Promise(resolve => {
+					phAssetImage.requestContentEditingInputWithOptionsCompletionHandler(imageOptions, (thing) => {
+						fileMap[existingFileName].path = thing.fullSizeImageURL.toString().replace('file://', '');
+						resolve();
+					});
 				});
 			}
 		}
 
 		if (this._resolve) {
-			setTimeout(() => {
-				const promises = [];
-				let count = 0;
-				for (const key in fileMap) {
-					const item = fileMap[key];
-					const folder = knownFolders.documents();
-					const extension = item.filename.split('.').pop();
-					let filename = renameFileTo ? renameFileTo + '.' + extension : item.filename;
-					if (iosAssets.count > 1) filename = renameFileTo ? renameFileTo + '-' + count + '.' + extension : item.filename;
-					fileMap[item.filename].filename = filename;
-					const fileManager = new NSFileManager();
-					if (copyToAppFolder) {
-						const filePath = path.join(folder.path + '/' + copyToAppFolder, filename);
+			if (!copyToAppFolder && augmentedAssetsInfo === false) {
+				return this._resolve(Object.values(fileMap));
+			}
+			const promises = [];
+			let count = 0;
+			for (const key in fileMap) {
+				const item = fileMap[key];
+				const folder = knownFolders.documents();
+				const extension = item.filename.split('.').pop();
+				let filename = renameFileTo ? renameFileTo + '.' + extension : item.filename;
+				if (iosAssets.count > 1) filename = renameFileTo ? renameFileTo + '-' + count + '.' + extension : item.filename;
+				fileMap[item.filename].filename = filename;
+				const fileManager = new NSFileManager();
+				if (copyToAppFolder) {
+					const filePath = path.join(folder.path + '/' + copyToAppFolder, filename);
+					promises.push(
+						getFile('file://' + item.path, filePath)
+							.then((result) => {
+								fileMap[item.originalFilename].path = filePath;
+								fileMap[item.originalFilename].filesize = fileManager.attributesOfItemAtPathError(filePath).fileSize();
+								if (item.type == 'video') {
+									return ImageSource.fromAsset(item.asset).then((source) => {
+										fileMap[item.originalFilename].thumbnail = source;
+									});
+								}
+							})
+							.catch((error) => {
+								console.log('Error copying file: ', error);
+							})
+					);
+				} else {
+					fileMap[item.originalFilename].filesize = fileManager.attributesOfItemAtPathError(fileMap[item.filename].path).fileSize();
+					if (item.type == 'video') {
 						promises.push(
-							getFile('file://' + item.path, filePath)
-								.then((result) => {
-									fileMap[item.originalFilename].path = filePath;
-									fileMap[item.originalFilename].filesize = fileManager.attributesOfItemAtPathError(filePath).fileSize();
-									if (item.type == 'video') {
-										return ImageSource.fromAsset(item.asset).then((source) => {
-											fileMap[item.originalFilename].thumbnail = source;
-										});
-									}
-								})
-								.catch((error) => {
-									console.log('Error copying file: ', error);
-								})
+							ImageSource.fromAsset(item.asset).then((source) => {
+								fileMap[item.originalFilename].thumbnail = source;
+							})
 						);
-					} else {
-						fileMap[item.originalFilename].filesize = fileManager.attributesOfItemAtPathError(fileMap[item.filename].path).fileSize();
-						if (item.type == 'video') {
-							promises.push(
-								ImageSource.fromAsset(item.asset).then((source) => {
-									fileMap[item.originalFilename].thumbnail = source;
-								})
-							);
-						}
 					}
-					count++;
 				}
+				count++;
+			}
 
-				Promise.all(promises).then(() => {
-					const results: ImagePickerSelection[] = [];
-					for (const key in fileMap) {
-						results.push(fileMap[key]);
-					}
-					this._resolve(results);
-				});
-			}, 300);
+			Promise.all(promises).then(() => {
+				const results: ImagePickerSelection[] = [];
+				for (const key in fileMap) {
+					results.push(fileMap[key]);
+				}
+				this._resolve(results);
+			});
 		}
 
 		imagePickerController.dismissViewControllerAnimatedCompletion(true, () => {


### PR DESCRIPTION
The code was wrong and would end up with empty path. The reason is that the path field was set after an async iOS method without awaiting with a promise. The timeout fix was not an actual fix.It would fail in many cases (slow device, too many item selected).
Now we use an async and await, thus we can remove the setTimeout.
Also added :
* `augementAssetsInfo` to allow for faster selection in many cases (no video selection for example) where thumbnail, copyToAppFolder, or filesize are not needed
* `resolveWhenDismissed` to wait for dismiss before resolving. important to be allowed to show another modal without the need of a dangerous setTimeout.

Please test this before any release