### PR TITLE
fix(local-notifications): Delete delivered notifications on iOS

### DIFF
--- a/packages/local-notifications/index.ios.ts
+++ b/packages/local-notifications/index.ios.ts
@@ -370,6 +370,7 @@ export class LocalNotificationsImpl extends LocalNotificationsCommon implements 
 			try {
 				if (LocalNotificationsImpl.isUNUserNotificationCenterAvailable()) {
 					UNUserNotificationCenter.currentNotificationCenter().removePendingNotificationRequestsWithIdentifiers(<any>['' + id]);
+					UNUserNotificationCenter.currentNotificationCenter().removeDeliveredNotificationsWithIdentifiers(<any>['' + id]);
 					resolve(true);
 				} else {
 					const scheduled = UIApplication.sharedApplication.scheduledLocalNotifications;
@@ -395,6 +396,7 @@ export class LocalNotificationsImpl extends LocalNotificationsCommon implements 
 			try {
 				if (LocalNotificationsImpl.isUNUserNotificationCenterAvailable()) {
 					UNUserNotificationCenter.currentNotificationCenter().removeAllPendingNotificationRequests();
+					UNUserNotificationCenter.currentNotificationCenter().removeAllDeliveredNotifications();
 				} else {
 					UIApplication.sharedApplication.cancelAllLocalNotifications();
 				}


### PR DESCRIPTION
When deleting notifications with `cancel()` or `cancelAll()`, on Android scheduled _and_ delivered notifications are deleted.
On iOS, _only_ scheduled notifications are deleted. Notifications that are already delivered remain. With the latest plugin version 6.3.0 there's no way to delete them.

This PR makes `cancel()` and `cancelAll()` work the same on both platforms by deleting delivered notifications on iOS too.