### PR TITLE
feat(imagepicker): support Android Photo Picker

### DIFF
--- a/packages/imagepicker/README.md
+++ b/packages/imagepicker/README.md
@@ -52,6 +52,8 @@ Add the following permissions to the `App_Resources/Android/src/main/AndroidMani
 
 - **targetSdkVersion >=33(Android 13+)**
 
+These are only required when not setting `android.use_photo_picker = true`.
+
 ```xml
 <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
@@ -59,6 +61,24 @@ Add the following permissions to the `App_Resources/Android/src/main/AndroidMani
 ```
 
 See the complete example [here](https://github.com/NativeScript/plugins/blob/main/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml#L14).
+
+### Android Photo picker ###
+
+For phones running android 13+ specifying the option `android.use_photo_picker = true` when creating the `ImagePicker` will result in the use of the System Photo Picker.
+
+<!-- tabs: TS -->
+```ts
+let imagePickerObj: ImagePicker = imagePickerPlugin.create({
+    mode: "single",
+	android: { use_photo_picker: true }});
+```
+This means you can remove the `READ_MEDIA_IMAGES, READ_MEDIA_VIDEO` permissions and do not have to prompt the user for permission.
+
+Full details [here](https://developer.android.com/training/data-storage/shared/photopicker).
+
+You can also now limit the number of images that are selectable in the Photo Picker by specifying the `maximumNumberOfSelection` option.
+
+For phones running  < Android 13, this `use_photo_picker` option has no effect.
 
 ### iOS required permissions
 
@@ -168,7 +188,7 @@ An object passed to the `create` method to specify the characteristics of a medi
 |:---------------------------|:-------- |:---------|:-------
 | `mode`                       | `string`     | `multiple`  | The mode of the imagepicker. Possible values are `single` for single selection and `multiple` for multiple selection.                              |
 | `minimumNumberOfSelection`    | `number`      | `0`         | _Optional_:  (`iOS-only`) The minumum number of selected assets.                                                                                                             |
-| `maximumNumberOfSelection`    | `number`      | `0`         | _Optional_:  (`iOS-only`) The maximum number of selected assets.                                                                                                             |
+| `maximumNumberOfSelection`    | `number`      | `0`         | _Optional_:  (`iOS-only`, `Android-Photo Picker-Only`) The maximum number of selected assets.                                                                                                             |
 | `showsNumberOfSelectedAssets` | `boolean`      | `true`      | _Optional_:  (`iOS-only`) Display the number of selected assets.                                                                                                             |
 | `prompt`                      | `string`      | `undefined` | _Optional_:  (`iOS-only`) Display prompt text when selecting assets.                                                                                                         |
 | `numberOfColumnsInPortrait`   | `number`      | `4`         | _Optional_:  (`iOS-only`) Sets the number of columns in Portrait orientation                                                                                                  |

--- a/packages/imagepicker/common.ts
+++ b/packages/imagepicker/common.ts
@@ -125,6 +125,10 @@ export interface Options {
 		 * Provide a reason for permission request to access external storage on api levels above 23.
 		 */
 		read_external_storage?: string;
+		/**
+		 * Use the Photo Picker on android
+		 */
+		use_photo_picker?: boolean;
 	};
 }
 

--- a/packages/imagepicker/index.android.ts
+++ b/packages/imagepicker/index.android.ts
@@ -188,150 +188,292 @@ export class ImagePicker extends ImagePickerBase {
 		}
 		return mimeTypes;
 	}
+	get maximumNumberOfSelection() {
+		if (this._options.maximumNumberOfSelection && this._options.maximumNumberOfSelection > 0) {
+			return this._options.maximumNumberOfSelection;
+		}
 
+		return 0;
+	}
+	private get usePhotoPicker(): boolean {
+		return this._options?.android?.use_photo_picker && Utils.SDK_VERSION >= 33;
+	}
 	authorize(): Promise<AuthorizationResult> {
-		let requested: { [key: string]: permissions.PermissionOptions } = {};
-		if (Utils.SDK_VERSION >= 33 && Utils.android.getApplicationContext().getApplicationInfo().targetSdkVersion >= 33) {
-			const mediaPerms = {
-				photo: { reason: 'To pick images from your gallery' },
-				video: { reason: 'To pick videos from your gallery' },
-			};
-			if (this.mediaType === 'image/*') {
-				requested['photo'] = mediaPerms['photo'];
-			} else if (this.mediaType === 'video/*') {
-				requested['video'] = mediaPerms['video'];
-			} else {
-				requested = mediaPerms;
-			}
-
-			return permissions.request(requested).then((result) => this.mapResult(result));
-		} else if ((<any>android).os.Build.VERSION.SDK_INT >= 23) {
-			requested['storage'] = { read: true, write: false };
-			return permissions.request(requested).then((result) => this.mapResult(result));
-		} else {
+		console.log('***** using photoPicker****', this.usePhotoPicker);
+		if (this.usePhotoPicker) {
+			const available = androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.isPhotoPickerAvailable(Utils.android.getApplicationContext());
+			console.log('Is available', available);
 			return Promise.resolve({ details: null, authorized: true });
+		} else {
+			let requested: { [key: string]: permissions.PermissionOptions } = {};
+			if (Utils.SDK_VERSION >= 33 && Utils.android.getApplicationContext().getApplicationInfo().targetSdkVersion >= 33) {
+				const mediaPerms = {
+					photo: { reason: 'To pick images from your gallery' },
+					video: { reason: 'To pick videos from your gallery' },
+				};
+				if (this.mediaType === 'image/*') {
+					requested['photo'] = mediaPerms['photo'];
+				} else if (this.mediaType === 'video/*') {
+					requested['video'] = mediaPerms['video'];
+				} else {
+					requested = mediaPerms;
+				}
+
+				return permissions.request(requested).then((result) => this.mapResult(result));
+			} else if ((<any>android).os.Build.VERSION.SDK_INT >= 23) {
+				requested['storage'] = { read: true, write: false };
+				return permissions.request(requested).then((result) => this.mapResult(result));
+			} else {
+				return Promise.resolve({ details: null, authorized: true });
+			}
 		}
 	}
 
 	present(): Promise<ImagePickerSelection[]> {
 		return new Promise((resolve, reject) => {
-			// WARNING: If we want to support multiple pickers we will need to have a range of IDs here:
-			let RESULT_CODE_PICKER_IMAGES = 9192;
+			if (this.usePhotoPicker) {
+				const REQUEST_LAUNCH_LIBRARY = 13003;
 
-			Application.android.on(Application.android.activityResultEvent, onResult);
+				Application.android.on(Application.android.activityResultEvent, onResult);
 
-			function onResult(args) {
-				let requestCode = args.requestCode;
-				let resultCode = args.resultCode;
-				let data = args.intent;
+				function onResult(args) {
+					let requestCode = args.requestCode;
+					if (requestCode === REQUEST_LAUNCH_LIBRARY) {
+						console.log('request code OK');
+						let resultCode = args.resultCode;
+						if (resultCode == android.app.Activity.RESULT_OK) {
+							try {
+								console.log('result code OK');
+								let data = args.intent;
 
-				const handle = (selectedAsset, i?) => {
-					const file = File.fromPath(selectedAsset.android);
-					let copiedFile: any = false;
-
-					const item: ImagePickerSelection = {
-						asset: selectedAsset,
-						filename: file.name,
-						originalFilename: file.name,
-						type: videoFiles[file.extension.replace('.', '')] ? 'video' : 'image',
-						path: file.path,
-						filesize: file.size,
-					};
-					if (copyToAppFolder) {
-						let extension = file.name.split('.').pop();
-						let filename = file.name;
-						if (renameFileTo) {
-							if (i || i === 0) {
-								filename = renameFileTo + '-' + i + '.' + extension;
-							} else {
-								filename = renameFileTo + '.' + extension;
-							}
-							item.filename = filename;
-						}
-						let newPath = knownFolders.documents().path + '/' + copyToAppFolder + '/' + filename;
-						copiedFile = File.fromPath(newPath);
-						item.path = newPath;
-						item.asset.android = item.path;
-						copiedFile.writeSync(file.readSync());
-						item.filesize = new java.io.File(item.path).length();
-					}
-					if (item.type == 'video') {
-						const thumb = android.media.ThumbnailUtils.createVideoThumbnail(copiedFile ? copiedFile.path : file.path, android.provider.MediaStore.Video.Thumbnails.MINI_KIND);
-						let retriever = new android.media.MediaMetadataRetriever();
-						retriever.setDataSource(item.path);
-						item.thumbnail = new ImageSource(thumb);
-						let time = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_DURATION);
-						let duration = parseInt(time) / 1000;
-						item.duration = duration;
-					}
-					return item;
-				};
-
-				if (requestCode === RESULT_CODE_PICKER_IMAGES) {
-					if (resultCode === android.app.Activity.RESULT_OK) {
-						try {
-							let results = [];
-							let clip = data.getClipData();
-							const useHelper = (<any>android).os.Build.VERSION.SDK_INT <= 28;
-							if (clip) {
-								let count = clip.getItemCount();
-								for (let i = 0; i < count; i++) {
-									let clipItem = clip.getItemAt(i);
-									if (clipItem) {
-										let uri = clipItem.getUri();
-										if (uri) {
-											const val = useHelper ? UriHelper._calculateFileUri(uri) : uri.toString();
-											const selectedAsset = new ImageAsset(val);
-											let item = handle(selectedAsset, i);
-											results.push(item);
+								console.log('&&&', args.requestCode, args.resultCode, args.intent, data.getData(), Array.isArray(data));
+								let uris = new Array<string>();
+								let clip = data.getClipData();
+								if (clip) {
+									console.log('has clip');
+									let count = clip.getItemCount();
+									for (let i = 0; i < count; i++) {
+										let clipItem = clip.getItemAt(i);
+										if (clipItem) {
+											let uri = clipItem.getUri();
+											if (uri) {
+												uris.push(uri.toString());
+											}
 										}
 									}
+								} else {
+									console.log('has NOT clip');
+									const uriData = data.getData();
+									const uri = uriData.toString();
+									uris = [uri];
 								}
-							} else {
-								const uri = data.getData();
-								const val = useHelper ? UriHelper._calculateFileUri(uri) : uri.toString();
-								const selectedAsset = new ImageAsset(val);
-								let item = handle(selectedAsset);
-								results.push(item);
-							}
 
-							Application.android.off(AndroidApplication.activityResultEvent, onResult);
-							resolve(results);
-							return;
-						} catch (e) {
+								const handle = (selectedAsset, i?) => {
+									const file = File.fromPath(selectedAsset.android);
+									let copiedFile: any = false;
+
+									const item: ImagePickerSelection = {
+										asset: selectedAsset,
+										filename: file.name,
+										originalFilename: file.name,
+										type: videoFiles[file.extension.replace('.', '')] ? 'video' : 'image',
+										path: file.path,
+										filesize: file.size,
+									};
+									if (copyToAppFolder) {
+										let extension = file.name.split('.').pop();
+										let filename = file.name;
+										if (renameFileTo) {
+											if (i || i === 0) {
+												filename = renameFileTo + '-' + i + '.' + extension;
+											} else {
+												filename = renameFileTo + '.' + extension;
+											}
+											item.filename = filename;
+										}
+										let newPath = knownFolders.documents().path + '/' + copyToAppFolder + '/' + filename;
+										copiedFile = File.fromPath(newPath);
+										item.path = newPath;
+										item.asset.android = item.path;
+										copiedFile.writeSync(file.readSync());
+										item.filesize = new java.io.File(item.path).length();
+									}
+									if (item.type == 'video') {
+										const thumb = android.media.ThumbnailUtils.createVideoThumbnail(copiedFile ? copiedFile.path : file.path, android.provider.MediaStore.Video.Thumbnails.MINI_KIND);
+										let retriever = new android.media.MediaMetadataRetriever();
+										retriever.setDataSource(item.path);
+										item.thumbnail = new ImageSource(thumb);
+										let time = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_DURATION);
+										let duration = parseInt(time) / 1000;
+										item.duration = duration;
+									}
+									return item;
+								};
+
+								let results = [];
+								for (let i = 0; i <= uris.length - 1; ++i) {
+									console.log('processing image', i);
+									const selectedAsset = new ImageAsset(uris[i].toString());
+									let item = handle(selectedAsset, i);
+									results.push(item);
+								}
+								Application.android.off(Application.android.activityResultEvent, onResult);
+								resolve(results);
+							} catch (e) {
+								console.log(e);
+								Application.android.off(Application.android.activityResultEvent, onResult);
+								reject(e);
+							}
+						} else {
 							Application.android.off(Application.android.activityResultEvent, onResult);
-							reject(e);
+							reject(new Error('Image picker activity result code ' + resultCode));
 							return;
 						}
-					} else {
-						Application.android.off(Application.android.activityResultEvent, onResult);
-						reject(new Error('Image picker activity result code ' + resultCode));
-						return;
 					}
 				}
+				let mediaType: androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType;
+
+				if (this.mediaType === 'image/*') {
+					mediaType = androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly.INSTANCE;
+				} else if (this.mediaType === 'video/*') {
+					mediaType = androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VideoOnly.INSTANCE;
+				} else {
+					mediaType = androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageAndVideo.INSTANCE;
+				}
+
+				const mediaRequest = new androidx.activity.result.PickVisualMediaRequest.Builder().setMediaType(mediaType).build();
+				let libraryIntent: android.content.Intent;
+				const maximumNumberOfSelection = this.maximumNumberOfSelection;
+				if (this.mode === 'multiple' && maximumNumberOfSelection !== 1) {
+					if (this.maximumNumberOfSelection > 0) {
+						libraryIntent = new androidx.activity.result.contract.ActivityResultContracts.PickMultipleVisualMedia(this.maximumNumberOfSelection).createIntent(Utils.android.getApplicationContext(), mediaRequest);
+					} else {
+						libraryIntent = new androidx.activity.result.contract.ActivityResultContracts.PickMultipleVisualMedia().createIntent(Utils.android.getApplicationContext(), mediaRequest);
+					}
+				} else {
+					libraryIntent = new androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia().createIntent(Utils.android.getApplicationContext(), mediaRequest);
+				}
+
+				Utils.android.getCurrentActivity().startActivityForResult(libraryIntent, REQUEST_LAUNCH_LIBRARY);
+			} else {
+				// WARNING: If we want to support multiple pickers we will need to have a range of IDs here:
+				let RESULT_CODE_PICKER_IMAGES = 9192;
+
+				Application.android.on(Application.android.activityResultEvent, onResult);
+
+				function onResult(args) {
+					let requestCode = args.requestCode;
+					let resultCode = args.resultCode;
+					let data = args.intent;
+
+					const handle = (selectedAsset, i?) => {
+						const file = File.fromPath(selectedAsset.android);
+						let copiedFile: any = false;
+
+						const item: ImagePickerSelection = {
+							asset: selectedAsset,
+							filename: file.name,
+							originalFilename: file.name,
+							type: videoFiles[file.extension.replace('.', '')] ? 'video' : 'image',
+							path: file.path,
+							filesize: file.size,
+						};
+						if (copyToAppFolder) {
+							let extension = file.name.split('.').pop();
+							let filename = file.name;
+							if (renameFileTo) {
+								if (i || i === 0) {
+									filename = renameFileTo + '-' + i + '.' + extension;
+								} else {
+									filename = renameFileTo + '.' + extension;
+								}
+								item.filename = filename;
+							}
+							let newPath = knownFolders.documents().path + '/' + copyToAppFolder + '/' + filename;
+							copiedFile = File.fromPath(newPath);
+							item.path = newPath;
+							item.asset.android = item.path;
+							copiedFile.writeSync(file.readSync());
+							item.filesize = new java.io.File(item.path).length();
+						}
+						if (item.type == 'video') {
+							const thumb = android.media.ThumbnailUtils.createVideoThumbnail(copiedFile ? copiedFile.path : file.path, android.provider.MediaStore.Video.Thumbnails.MINI_KIND);
+							let retriever = new android.media.MediaMetadataRetriever();
+							retriever.setDataSource(item.path);
+							item.thumbnail = new ImageSource(thumb);
+							let time = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_DURATION);
+							let duration = parseInt(time) / 1000;
+							item.duration = duration;
+						}
+						return item;
+					};
+
+					if (requestCode === RESULT_CODE_PICKER_IMAGES) {
+						if (resultCode === android.app.Activity.RESULT_OK) {
+							try {
+								let results = [];
+								let clip = data.getClipData();
+								const useHelper = (<any>android).os.Build.VERSION.SDK_INT <= 28;
+								if (clip) {
+									let count = clip.getItemCount();
+									for (let i = 0; i < count; i++) {
+										let clipItem = clip.getItemAt(i);
+										if (clipItem) {
+											let uri = clipItem.getUri();
+											if (uri) {
+												const val = useHelper ? UriHelper._calculateFileUri(uri) : uri.toString();
+												const selectedAsset = new ImageAsset(val);
+												let item = handle(selectedAsset, i);
+												results.push(item);
+											}
+										}
+									}
+								} else {
+									const uri = data.getData();
+									const val = useHelper ? UriHelper._calculateFileUri(uri) : uri.toString();
+									const selectedAsset = new ImageAsset(val);
+									let item = handle(selectedAsset);
+									results.push(item);
+								}
+
+								Application.android.off(AndroidApplication.activityResultEvent, onResult);
+								resolve(results);
+								return;
+							} catch (e) {
+								Application.android.off(Application.android.activityResultEvent, onResult);
+								reject(e);
+								return;
+							}
+						} else {
+							Application.android.off(Application.android.activityResultEvent, onResult);
+							reject(new Error('Image picker activity result code ' + resultCode));
+							return;
+						}
+					}
+				}
+
+				let Intent = android.content.Intent;
+				let intent = new Intent();
+				intent.setType(this.mediaType);
+
+				// not in platform-declaration typings
+				intent.putExtra(android.content.Intent.EXTRA_MIME_TYPES, this.mimeTypes);
+
+				// TODO: Use (<any>android).content.Intent.EXTRA_ALLOW_MULTIPLE
+				if (this.mode === 'multiple') {
+					intent.putExtra('android.intent.extra.ALLOW_MULTIPLE', true);
+				}
+
+				if (this._options.showAdvanced) {
+					intent.putExtra('android.content.extra.SHOW_ADVANCED', true);
+				}
+
+				intent.putExtra(android.content.Intent.EXTRA_LOCAL_ONLY, true);
+				intent.setAction('android.intent.action.OPEN_DOCUMENT');
+				intent.addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION | android.content.Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+				let chooser = Intent.createChooser(intent, 'Select Picture');
+				Utils.android.getCurrentActivity().startActivityForResult(intent, RESULT_CODE_PICKER_IMAGES);
 			}
-
-			let Intent = android.content.Intent;
-			let intent = new Intent();
-			intent.setType(this.mediaType);
-
-			// not in platform-declaration typings
-			intent.putExtra(android.content.Intent.EXTRA_MIME_TYPES, this.mimeTypes);
-
-			// TODO: Use (<any>android).content.Intent.EXTRA_ALLOW_MULTIPLE
-			if (this.mode === 'multiple') {
-				intent.putExtra('android.intent.extra.ALLOW_MULTIPLE', true);
-			}
-
-			if (this._options.showAdvanced) {
-				intent.putExtra('android.content.extra.SHOW_ADVANCED', true);
-			}
-
-			intent.putExtra(android.content.Intent.EXTRA_LOCAL_ONLY, true);
-			intent.setAction('android.intent.action.OPEN_DOCUMENT');
-			intent.addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION | android.content.Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
-			let chooser = Intent.createChooser(intent, 'Select Picture');
-			Utils.android.getCurrentActivity().startActivityForResult(intent, RESULT_CODE_PICKER_IMAGES);
 		});
 	}
 }

--- a/packages/imagepicker/index.android.ts
+++ b/packages/imagepicker/index.android.ts
@@ -199,10 +199,7 @@ export class ImagePicker extends ImagePickerBase {
 		return this._options?.android?.use_photo_picker && Utils.SDK_VERSION >= 33;
 	}
 	authorize(): Promise<AuthorizationResult> {
-		console.log('***** using photoPicker****', this.usePhotoPicker);
 		if (this.usePhotoPicker) {
-			const available = androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.isPhotoPickerAvailable(Utils.android.getApplicationContext());
-			console.log('Is available', available);
 			return Promise.resolve({ details: null, authorized: true });
 		} else {
 			let requested: { [key: string]: permissions.PermissionOptions } = {};
@@ -239,18 +236,13 @@ export class ImagePicker extends ImagePickerBase {
 				function onResult(args) {
 					let requestCode = args.requestCode;
 					if (requestCode === REQUEST_LAUNCH_LIBRARY) {
-						console.log('request code OK');
 						let resultCode = args.resultCode;
 						if (resultCode == android.app.Activity.RESULT_OK) {
 							try {
-								console.log('result code OK');
 								let data = args.intent;
-
-								console.log('&&&', args.requestCode, args.resultCode, args.intent, data.getData(), Array.isArray(data));
 								let uris = new Array<string>();
 								let clip = data.getClipData();
 								if (clip) {
-									console.log('has clip');
 									let count = clip.getItemCount();
 									for (let i = 0; i < count; i++) {
 										let clipItem = clip.getItemAt(i);
@@ -262,7 +254,6 @@ export class ImagePicker extends ImagePickerBase {
 										}
 									}
 								} else {
-									console.log('has NOT clip');
 									const uriData = data.getData();
 									const uri = uriData.toString();
 									uris = [uri];
@@ -312,7 +303,6 @@ export class ImagePicker extends ImagePickerBase {
 
 								let results = [];
 								for (let i = 0; i <= uris.length - 1; ++i) {
-									console.log('processing image', i);
 									const selectedAsset = new ImageAsset(uris[i].toString());
 									let item = handle(selectedAsset, i);
 									results.push(item);
@@ -320,7 +310,6 @@ export class ImagePicker extends ImagePickerBase {
 								Application.android.off(Application.android.activityResultEvent, onResult);
 								resolve(results);
 							} catch (e) {
-								console.log(e);
 								Application.android.off(Application.android.activityResultEvent, onResult);
 								reject(e);
 							}

--- a/packages/imagepicker/index.d.ts
+++ b/packages/imagepicker/index.d.ts
@@ -79,7 +79,7 @@ interface Options {
 	minimumNumberOfSelection?: number;
 
 	/**
-	 * Set the maximum number of selected assets in iOS
+	 * Set the maximum number of selected assets in iOS, and android using the photo picker option.
 	 */
 	maximumNumberOfSelection?: number;
 

--- a/packages/imagepicker/index.d.ts
+++ b/packages/imagepicker/index.d.ts
@@ -140,6 +140,10 @@ interface Options {
 		 * Provide a reason for permission request to access external storage on api levels above 23.
 		 */
 		read_external_storage?: string;
+		/**
+		 * Use the Photo Picker on android
+		 */
+		use_photo_picker?: boolean;
 	};
 }
 

--- a/packages/imagepicker/platforms/android/include.gradle
+++ b/packages/imagepicker/platforms/android/include.gradle
@@ -1,0 +1,4 @@
+dependencies {
+   
+    implementation("androidx.activity:activity:1.9.+")
+}

--- a/packages/imagepicker/references.d.ts
+++ b/packages/imagepicker/references.d.ts
@@ -1,2 +1,3 @@
-/// <reference path="../../references.d.ts" />
 /// <reference path="./typings/objc!QBImagePickerController.d.ts" />
+/// <reference path="./typings/android.d.ts" />
+/// <reference path="../../references.d.ts" />

--- a/packages/imagepicker/typings/android.d.ts
+++ b/packages/imagepicker/typings/android.d.ts
@@ -1,0 +1,1033 @@
+/// <reference path="android-declarations.d.ts"/>
+
+declare module androidx {
+	export module activity {
+		export class Api26Impl {
+			public static class: java.lang.Class<androidx.activity.Api26Impl>;
+			public static INSTANCE: androidx.activity.Api26Impl;
+			public setPipParamsSourceRectHint(activity: globalAndroid.app.Activity, hint: globalAndroid.graphics.Rect): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class Api34Impl {
+			public static class: java.lang.Class<androidx.activity.Api34Impl>;
+			public static INSTANCE: androidx.activity.Api34Impl;
+			public touchX(backEvent: globalAndroid.window.BackEvent): number;
+			public swipeEdge(backEvent: globalAndroid.window.BackEvent): number;
+			public createOnBackEvent(touchX: number, touchY: number, progress: number, swipeEdge: number): globalAndroid.window.BackEvent;
+			public touchY(backEvent: globalAndroid.window.BackEvent): number;
+			public progress(backEvent: globalAndroid.window.BackEvent): number;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class BackEventCompat {
+			public static class: java.lang.Class<androidx.activity.BackEventCompat>;
+			public static EDGE_LEFT: number = 0;
+			public static EDGE_RIGHT: number = 1;
+			public getProgress(): number;
+			public toString(): string;
+			public constructor(touchX: number, touchY: number, progress: number, swipeEdge: number);
+			public toBackEvent(): globalAndroid.window.BackEvent;
+			public constructor(backEvent: globalAndroid.window.BackEvent);
+			public getTouchX(): number;
+			public getSwipeEdge(): number;
+			public getTouchY(): number;
+		}
+		export module BackEventCompat {
+			export class Companion {
+				public static class: java.lang.Class<androidx.activity.BackEventCompat.Companion>;
+			}
+			export class SwipeEdge {
+				public static class: java.lang.Class<androidx.activity.BackEventCompat.SwipeEdge>;
+				/**
+				 * Constructs a new instance of the androidx.activity.BackEventCompat$SwipeEdge interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {});
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class Cancellable {
+			public static class: java.lang.Class<androidx.activity.Cancellable>;
+			/**
+			 * Constructs a new instance of the androidx.activity.Cancellable interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: { cancel(): void });
+			public constructor();
+			public cancel(): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class ComponentActivity implements androidx.activity.contextaware.ContextAware, androidx.activity.OnBackPressedDispatcherOwner, androidx.activity.result.ActivityResultRegistryOwner, androidx.activity.result.ActivityResultCaller, androidx.activity.FullyDrawnReporterOwner {
+			public static class: java.lang.Class<androidx.activity.ComponentActivity>;
+			public getSavedStateRegistry(): androidx.savedstate.SavedStateRegistry;
+			public removeOnTrimMemoryListener(listener: androidx.core.util.Consumer<java.lang.Integer>): void;
+			public initializeViewTreeOwners(): void;
+			public getFullyDrawnReporter(): androidx.activity.FullyDrawnReporter;
+			public addOnConfigurationChangedListener(listener: androidx.core.util.Consumer<globalAndroid.content.res.Configuration>): void;
+			/** @deprecated */
+			public onRetainCustomNonConfigurationInstance(): any;
+			public onTrimMemory(this_: number): void;
+			public onMultiWindowModeChanged(this_: boolean, isInMultiWindowMode: globalAndroid.content.res.Configuration): void;
+			public removeOnPictureInPictureModeChangedListener(listener: androidx.core.util.Consumer<androidx.core.app.PictureInPictureModeChangedInfo>): void;
+			public onCreatePanelMenu(featureId: number, menu: globalAndroid.view.Menu): boolean;
+			public onCreate(savedInstanceState: globalAndroid.os.Bundle): void;
+			public getDefaultViewModelProviderFactory(): androidx.lifecycle.ViewModelProvider.Factory;
+			public peekAvailableContext(): globalAndroid.content.Context;
+			/** @deprecated */
+			public onBackPressed(): void;
+			public addOnMultiWindowModeChangedListener(listener: androidx.core.util.Consumer<androidx.core.app.MultiWindowModeChangedInfo>): void;
+			public onPanelClosed(featureId: number, menu: globalAndroid.view.Menu): void;
+			public removeOnNewIntentListener(listener: androidx.core.util.Consumer<globalAndroid.content.Intent>): void;
+			/** @deprecated */
+			public getLastCustomNonConfigurationInstance(): any;
+			public onConfigurationChanged(this_: globalAndroid.content.res.Configuration): void;
+			public removeOnUserLeaveHintListener(listener: java.lang.Runnable): void;
+			public invalidateMenu(): void;
+			public constructor();
+			/** @deprecated */
+			public onPictureInPictureModeChanged(this_: boolean): void;
+			public addMenuProvider(provider: androidx.core.view.MenuProvider, owner: androidx.lifecycle.LifecycleOwner, state: androidx.lifecycle.Lifecycle.State): void;
+			public getViewModelStore(): androidx.lifecycle.ViewModelStore;
+			public addOnContextAvailableListener(param0: androidx.activity.contextaware.OnContextAvailableListener): void;
+			public onPreparePanel(featureId: number, view: globalAndroid.view.View, menu: globalAndroid.view.Menu): boolean;
+			public onNewIntent(this_: globalAndroid.content.Intent): void;
+			/** @deprecated */
+			public startActivityForResult(intent: globalAndroid.content.Intent, requestCode: number): void;
+			public registerForActivityResult(param0: androidx.activity.result.contract.ActivityResultContract<any, any>, param1: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>;
+			public constructor(contentLayoutId: number);
+			public removeOnContextAvailableListener(param0: androidx.activity.contextaware.OnContextAvailableListener): void;
+			public removeOnContextAvailableListener(listener: androidx.activity.contextaware.OnContextAvailableListener): void;
+			public registerForActivityResult(contract: androidx.activity.result.contract.ActivityResultContract<any, any>, registry: androidx.activity.result.ActivityResultRegistry, callback: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>;
+			public addOnUserLeaveHintListener(listener: java.lang.Runnable): void;
+			public onRetainNonConfigurationInstance(): any;
+			public reportFullyDrawn(): void;
+			public addOnContextAvailableListener(listener: androidx.activity.contextaware.OnContextAvailableListener): void;
+			/** @deprecated */
+			public startActivityForResult(intent: globalAndroid.content.Intent, requestCode: number, options: globalAndroid.os.Bundle): void;
+			public setContentView(view: globalAndroid.view.View, params: globalAndroid.view.ViewGroup.LayoutParams): void;
+			public getOnBackPressedDispatcher(): androidx.activity.OnBackPressedDispatcher;
+			public onSaveInstanceState(outState: globalAndroid.os.Bundle): void;
+			public onMenuItemSelected(featureId: number, item: globalAndroid.view.MenuItem): boolean;
+			public getDefaultViewModelCreationExtras(): androidx.lifecycle.viewmodel.CreationExtras;
+			/** @deprecated */
+			public onMultiWindowModeChanged(this_: boolean): void;
+			public removeOnConfigurationChangedListener(listener: androidx.core.util.Consumer<globalAndroid.content.res.Configuration>): void;
+			public addOnTrimMemoryListener(listener: androidx.core.util.Consumer<java.lang.Integer>): void;
+			public registerForActivityResult(contract: androidx.activity.result.contract.ActivityResultContract<any, any>, callback: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>;
+			public removeOnMultiWindowModeChangedListener(listener: androidx.core.util.Consumer<androidx.core.app.MultiWindowModeChangedInfo>): void;
+			public setContentView(view: globalAndroid.view.View): void;
+			public addOnNewIntentListener(listener: androidx.core.util.Consumer<globalAndroid.content.Intent>): void;
+			public onPictureInPictureModeChanged(this_: boolean, isInPictureInPictureMode: globalAndroid.content.res.Configuration): void;
+			public setContentView(layoutResID: number): void;
+			public getLifecycle(): androidx.lifecycle.Lifecycle;
+			public registerForActivityResult(param0: androidx.activity.result.contract.ActivityResultContract<any, any>, param1: androidx.activity.result.ActivityResultRegistry, param2: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>;
+			/** @deprecated */
+			public startIntentSenderForResult(intent: globalAndroid.content.IntentSender, requestCode: number, fillInIntent: globalAndroid.content.Intent, flagsMask: number, flagsValues: number, extraFlags: number, options: globalAndroid.os.Bundle): void;
+			public addMenuProvider(provider: androidx.core.view.MenuProvider): void;
+			public onUserLeaveHint(): void;
+			public addContentView(view: globalAndroid.view.View, params: globalAndroid.view.ViewGroup.LayoutParams): void;
+			/** @deprecated */
+			public startIntentSenderForResult(intent: globalAndroid.content.IntentSender, requestCode: number, fillInIntent: globalAndroid.content.Intent, flagsMask: number, flagsValues: number, extraFlags: number): void;
+			public getActivityResultRegistry(): androidx.activity.result.ActivityResultRegistry;
+			public removeMenuProvider(provider: androidx.core.view.MenuProvider): void;
+			/** @deprecated */
+			public onRequestPermissionsResult(requestCode: number, permissions: androidNative.Array<string>, grantResults: androidNative.Array<number>): void;
+			/** @deprecated */
+			public onActivityResult(requestCode: number, resultCode: number, data: globalAndroid.content.Intent): void;
+			public addOnPictureInPictureModeChangedListener(listener: androidx.core.util.Consumer<androidx.core.app.PictureInPictureModeChangedInfo>): void;
+			public addMenuProvider(provider: androidx.core.view.MenuProvider, owner: androidx.lifecycle.LifecycleOwner): void;
+		}
+		export module ComponentActivity {
+			export class Api33Impl {
+				public static class: java.lang.Class<androidx.activity.ComponentActivity.Api33Impl>;
+				public static INSTANCE: androidx.activity.ComponentActivity.Api33Impl;
+				public getOnBackInvokedDispatcher(activity: globalAndroid.app.Activity): globalAndroid.window.OnBackInvokedDispatcher;
+			}
+			export class Companion {
+				public static class: java.lang.Class<androidx.activity.ComponentActivity.Companion>;
+			}
+			export class ReportFullyDrawnExecutor {
+				public static class: java.lang.Class<androidx.activity.ComponentActivity.ReportFullyDrawnExecutor>;
+				/**
+				 * Constructs a new instance of the androidx.activity.ComponentActivity$ReportFullyDrawnExecutor interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: { viewCreated(param0: globalAndroid.view.View): void; activityDestroyed(): void });
+				public constructor();
+				public viewCreated(param0: globalAndroid.view.View): void;
+				public activityDestroyed(): void;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class ComponentDialog implements androidx.activity.OnBackPressedDispatcherOwner {
+			public static class: java.lang.Class<androidx.activity.ComponentDialog>;
+			public onStart(): void;
+			public constructor(context: globalAndroid.content.Context);
+			public getSavedStateRegistry(): androidx.savedstate.SavedStateRegistry;
+			public setContentView(view: globalAndroid.view.View): void;
+			public constructor(context: globalAndroid.content.Context, themeResId: number);
+			public initializeViewTreeOwners(): void;
+			public getLifecycle(): androidx.lifecycle.Lifecycle;
+			public setContentView(layoutResID: number): void;
+			public getOnBackPressedDispatcher(): androidx.activity.OnBackPressedDispatcher;
+			public setContentView(view: globalAndroid.view.View, params: globalAndroid.view.ViewGroup.LayoutParams): void;
+			public onBackPressed(): void;
+			public addContentView(view: globalAndroid.view.View, params: globalAndroid.view.ViewGroup.LayoutParams): void;
+			public onSaveInstanceState(): globalAndroid.os.Bundle;
+			public onCreate(savedInstanceState: globalAndroid.os.Bundle): void;
+			public onStop(): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdge {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdge>;
+			public static enable($this$enableEdgeToEdge: androidx.activity.ComponentActivity): void;
+			public static enable($this$enableEdgeToEdge: androidx.activity.ComponentActivity, statusBarStyle: androidx.activity.SystemBarStyle): void;
+			public static getDefaultDarkScrim(): number;
+			public static getDefaultLightScrim(): number;
+			public static enable($i$a$alsoEdgeToEdge$enableEdgeToEdge$impl$1: androidx.activity.ComponentActivity, it: androidx.activity.SystemBarStyle, view: androidx.activity.SystemBarStyle): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdgeApi21 extends androidx.activity.EdgeToEdgeBase {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdgeApi21>;
+			public setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void;
+			public constructor();
+			public adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void;
+			public setUp(statusBarStyle: androidx.activity.SystemBarStyle, navigationBarStyle: androidx.activity.SystemBarStyle, window: globalAndroid.view.Window, view: globalAndroid.view.View, statusBarIsDark: boolean, navigationBarIsDark: boolean): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdgeApi23 extends androidx.activity.EdgeToEdgeBase {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdgeApi23>;
+			public setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void;
+			public constructor();
+			public adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void;
+			public setUp(statusBarStyle: androidx.activity.SystemBarStyle, navigationBarStyle: androidx.activity.SystemBarStyle, window: globalAndroid.view.Window, view: globalAndroid.view.View, statusBarIsDark: boolean, navigationBarIsDark: boolean): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdgeApi26 extends androidx.activity.EdgeToEdgeBase {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdgeApi26>;
+			public setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void;
+			public constructor();
+			public setUp($this$setUp_u24lambda_u240: androidx.activity.SystemBarStyle, this_: androidx.activity.SystemBarStyle, statusBarStyle: globalAndroid.view.Window, navigationBarStyle: globalAndroid.view.View, window: boolean, view: boolean): void;
+			public adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdgeApi28 extends androidx.activity.EdgeToEdgeApi26 {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdgeApi28>;
+			public setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void;
+			public constructor();
+			public adjustLayoutInDisplayCutoutMode(window: globalAndroid.view.Window): void;
+			public adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdgeApi29 extends androidx.activity.EdgeToEdgeApi28 {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdgeApi29>;
+			public setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void;
+			public constructor();
+			public setUp($this$setUp_u24lambda_u240: androidx.activity.SystemBarStyle, this_: androidx.activity.SystemBarStyle, statusBarStyle: globalAndroid.view.Window, navigationBarStyle: globalAndroid.view.View, window: boolean, view: boolean): void;
+			public adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdgeApi30 extends androidx.activity.EdgeToEdgeApi29 {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdgeApi30>;
+			public setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void;
+			public constructor();
+			public adjustLayoutInDisplayCutoutMode(window: globalAndroid.view.Window): void;
+			public adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdgeBase extends androidx.activity.EdgeToEdgeImpl {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdgeBase>;
+			public setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void;
+			public constructor();
+			public adjustLayoutInDisplayCutoutMode(window: globalAndroid.view.Window): void;
+			public adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void;
+			public setUp(statusBarStyle: androidx.activity.SystemBarStyle, navigationBarStyle: androidx.activity.SystemBarStyle, window: globalAndroid.view.Window, view: globalAndroid.view.View, statusBarIsDark: boolean, navigationBarIsDark: boolean): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class EdgeToEdgeImpl {
+			public static class: java.lang.Class<androidx.activity.EdgeToEdgeImpl>;
+			/**
+			 * Constructs a new instance of the androidx.activity.EdgeToEdgeImpl interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: { setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void; adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void });
+			public constructor();
+			public setUp(param0: androidx.activity.SystemBarStyle, param1: androidx.activity.SystemBarStyle, param2: globalAndroid.view.Window, param3: globalAndroid.view.View, param4: boolean, param5: boolean): void;
+			public adjustLayoutInDisplayCutoutMode(param0: globalAndroid.view.Window): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class FullyDrawnReporter {
+			public static class: java.lang.Class<androidx.activity.FullyDrawnReporter>;
+			public removeOnReportDrawnListener(this_: any): void;
+			public fullyDrawnReported(): void;
+			public isFullyDrawnReported(): boolean;
+			public removeReporter(): void;
+			public constructor(executor: java.util.concurrent.Executor, reportFullyDrawn: any);
+			public addOnReportDrawnListener(callImmediately: any): void;
+			public addReporter(): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class FullyDrawnReporterOwner {
+			public static class: java.lang.Class<androidx.activity.FullyDrawnReporterOwner>;
+			/**
+			 * Constructs a new instance of the androidx.activity.FullyDrawnReporterOwner interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: { getFullyDrawnReporter(): androidx.activity.FullyDrawnReporter });
+			public constructor();
+			public getFullyDrawnReporter(): androidx.activity.FullyDrawnReporter;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class ImmLeaksCleaner {
+			public static class: java.lang.Class<androidx.activity.ImmLeaksCleaner>;
+			public onStateChanged(servedView: androidx.lifecycle.LifecycleOwner, $i$a$synchronizedImmLeaksCleaner$onStateChanged$1$success$1: androidx.lifecycle.Lifecycle.Event): void;
+			public constructor(activity: globalAndroid.app.Activity);
+		}
+		export module ImmLeaksCleaner {
+			export abstract class Cleaner {
+				public static class: java.lang.Class<androidx.activity.ImmLeaksCleaner.Cleaner>;
+				public getServedView(param0: globalAndroid.view.inputmethod.InputMethodManager): globalAndroid.view.View;
+				public getLock(param0: globalAndroid.view.inputmethod.InputMethodManager): any;
+				public clearNextServedView(param0: globalAndroid.view.inputmethod.InputMethodManager): boolean;
+			}
+			export class Companion {
+				public static class: java.lang.Class<androidx.activity.ImmLeaksCleaner.Companion>;
+				public getCleaner(): androidx.activity.ImmLeaksCleaner.Cleaner;
+			}
+			export class FailedInitialization extends androidx.activity.ImmLeaksCleaner.Cleaner {
+				public static class: java.lang.Class<androidx.activity.ImmLeaksCleaner.FailedInitialization>;
+				public static INSTANCE: androidx.activity.ImmLeaksCleaner.FailedInitialization;
+				public getLock($this$lock: globalAndroid.view.inputmethod.InputMethodManager): any;
+				public getServedView($this$servedView: globalAndroid.view.inputmethod.InputMethodManager): globalAndroid.view.View;
+				public clearNextServedView($this$clearNextServedView: globalAndroid.view.inputmethod.InputMethodManager): boolean;
+			}
+			export class ValidCleaner extends androidx.activity.ImmLeaksCleaner.Cleaner {
+				public static class: java.lang.Class<androidx.activity.ImmLeaksCleaner.ValidCleaner>;
+				public constructor(hField: java.lang.reflect.Field, servedViewField: java.lang.reflect.Field, nextServedViewField: java.lang.reflect.Field);
+				public getServedView(e: globalAndroid.view.inputmethod.InputMethodManager): globalAndroid.view.View;
+				public clearNextServedView(this_: globalAndroid.view.inputmethod.InputMethodManager): boolean;
+				public getLock(this_: globalAndroid.view.inputmethod.InputMethodManager): any;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class OnBackPressedDispatcher {
+			public static class: java.lang.Class<androidx.activity.OnBackPressedDispatcher>;
+			public constructor(fallbackOnBackPressed: java.lang.Runnable, onHasEnabledCallbacksChanged: androidx.core.util.Consumer<java.lang.Boolean>);
+			public dispatchOnBackProgressed(backEvent: androidx.activity.BackEventCompat): void;
+			public constructor(fallbackOnBackPressed: java.lang.Runnable);
+			public addCancellableCallback$activity_release(this_: androidx.activity.OnBackPressedCallback): androidx.activity.Cancellable;
+			public addCallback(this_: androidx.lifecycle.LifecycleOwner, owner: androidx.activity.OnBackPressedCallback): void;
+			public onBackPressed(): void;
+			public dispatchOnBackCancelled(): void;
+			public setOnBackInvokedDispatcher(invoker: globalAndroid.window.OnBackInvokedDispatcher): void;
+			public addCallback(onBackPressedCallback: androidx.activity.OnBackPressedCallback): void;
+			public dispatchOnBackStarted(backEvent: androidx.activity.BackEventCompat): void;
+			public constructor();
+			public hasEnabledCallbacks(): boolean;
+		}
+		export module OnBackPressedDispatcher {
+			export class Api33Impl {
+				public static class: java.lang.Class<androidx.activity.OnBackPressedDispatcher.Api33Impl>;
+				public static INSTANCE: androidx.activity.OnBackPressedDispatcher.Api33Impl;
+				public createOnBackInvokedCallback(onBackInvoked: any): globalAndroid.window.OnBackInvokedCallback;
+				public registerOnBackInvokedCallback(onBackInvokedCallback: any, this_: number, dispatcher: any): void;
+				public unregisterOnBackInvokedCallback(onBackInvokedCallback: any, this_: any): void;
+			}
+			export class Api34Impl {
+				public static class: java.lang.Class<androidx.activity.OnBackPressedDispatcher.Api34Impl>;
+				public static INSTANCE: androidx.activity.OnBackPressedDispatcher.Api34Impl;
+				public createOnBackAnimationCallback(onBackStarted: any, onBackProgressed: any, onBackInvoked: any, onBackCancelled: any): globalAndroid.window.OnBackInvokedCallback;
+			}
+			export class LifecycleOnBackPressedCancellable extends androidx.activity.Cancellable {
+				public static class: java.lang.Class<androidx.activity.OnBackPressedDispatcher.LifecycleOnBackPressedCancellable>;
+				public onStateChanged(source: androidx.lifecycle.LifecycleOwner, event: androidx.lifecycle.Lifecycle.Event): void;
+				public cancel(): void;
+				public constructor(this$0: androidx.lifecycle.Lifecycle, lifecycle: androidx.activity.OnBackPressedCallback);
+			}
+			export class OnBackPressedCancellable extends androidx.activity.Cancellable {
+				public static class: java.lang.Class<androidx.activity.OnBackPressedDispatcher.OnBackPressedCancellable>;
+				public constructor(this$0: androidx.activity.OnBackPressedCallback);
+				public cancel(): void;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class OnBackPressedDispatcherOwner {
+			public static class: java.lang.Class<androidx.activity.OnBackPressedDispatcherOwner>;
+			/**
+			 * Constructs a new instance of the androidx.activity.OnBackPressedDispatcherOwner interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: { getOnBackPressedDispatcher(): androidx.activity.OnBackPressedDispatcher });
+			public constructor();
+			public getOnBackPressedDispatcher(): androidx.activity.OnBackPressedDispatcher;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class SystemBarStyle {
+			public static class: java.lang.Class<androidx.activity.SystemBarStyle>;
+			public getDarkScrim$activity_release(): number;
+			public getNightMode$activity_release(): number;
+			public getScrim$activity_release(isDark: boolean): number;
+			public static light(scrim: number, darkScrim: number): androidx.activity.SystemBarStyle;
+			public getDetectDarkMode$activity_release(): any;
+			public getScrimWithEnforcedContrast$activity_release(isDark: boolean): number;
+			public static dark(scrim: number): androidx.activity.SystemBarStyle;
+			public static auto(lightScrim: number, darkScrim: number, detectDarkMode: any): androidx.activity.SystemBarStyle;
+			public static auto(lightScrim: number, darkScrim: number): androidx.activity.SystemBarStyle;
+		}
+		export module SystemBarStyle {
+			export class Companion {
+				public static class: java.lang.Class<androidx.activity.SystemBarStyle.Companion>;
+				public dark(scrim: number): androidx.activity.SystemBarStyle;
+				public auto(lightScrim: number, darkScrim: number): androidx.activity.SystemBarStyle;
+				public auto(lightScrim: number, darkScrim: number, detectDarkMode: any): androidx.activity.SystemBarStyle;
+				public light(scrim: number, darkScrim: number): androidx.activity.SystemBarStyle;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class ViewTreeFullyDrawnReporterOwner {
+			public static class: java.lang.Class<androidx.activity.ViewTreeFullyDrawnReporterOwner>;
+			public static get($this$findViewTreeFullyDrawnReporterOwner: globalAndroid.view.View): androidx.activity.FullyDrawnReporterOwner;
+			public static set($this$setViewTreeFullyDrawnReporterOwner: globalAndroid.view.View, fullyDrawnReporterOwner: androidx.activity.FullyDrawnReporterOwner): void;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export class ViewTreeOnBackPressedDispatcherOwner {
+			public static class: java.lang.Class<androidx.activity.ViewTreeOnBackPressedDispatcherOwner>;
+			public static set($this$setViewTreeOnBackPressedDispatcherOwner: globalAndroid.view.View, onBackPressedDispatcherOwner: androidx.activity.OnBackPressedDispatcherOwner): void;
+			public static get($this$findViewTreeOnBackPressedDispatcherOwner: globalAndroid.view.View): androidx.activity.OnBackPressedDispatcherOwner;
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module contextaware {
+			export class ContextAware {
+				public static class: java.lang.Class<androidx.activity.contextaware.ContextAware>;
+				/**
+				 * Constructs a new instance of the androidx.activity.contextaware.ContextAware interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: { peekAvailableContext(): globalAndroid.content.Context; addOnContextAvailableListener(param0: androidx.activity.contextaware.OnContextAvailableListener): void; removeOnContextAvailableListener(param0: androidx.activity.contextaware.OnContextAvailableListener): void });
+				public constructor();
+				public addOnContextAvailableListener(param0: androidx.activity.contextaware.OnContextAvailableListener): void;
+				public peekAvailableContext(): globalAndroid.content.Context;
+				public removeOnContextAvailableListener(param0: androidx.activity.contextaware.OnContextAvailableListener): void;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module contextaware {
+			export class ContextAwareHelper {
+				public static class: java.lang.Class<androidx.activity.contextaware.ContextAwareHelper>;
+				public addOnContextAvailableListener(it: androidx.activity.contextaware.OnContextAvailableListener): void;
+				public removeOnContextAvailableListener(listener: androidx.activity.contextaware.OnContextAvailableListener): void;
+				public clearAvailableContext(): void;
+				public peekAvailableContext(): globalAndroid.content.Context;
+				public dispatchOnContextAvailable(this_: globalAndroid.content.Context): void;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module contextaware {
+			export class OnContextAvailableListener {
+				public static class: java.lang.Class<androidx.activity.contextaware.OnContextAvailableListener>;
+				/**
+				 * Constructs a new instance of the androidx.activity.contextaware.OnContextAvailableListener interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: { onContextAvailable(param0: globalAndroid.content.Context): void });
+				public constructor();
+				public onContextAvailable(param0: globalAndroid.content.Context): void;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export class ActivityResult {
+				public static class: java.lang.Class<androidx.activity.result.ActivityResult>;
+				public static CREATOR: globalAndroid.os.Parcelable.Creator<androidx.activity.result.ActivityResult>;
+				public getData(): globalAndroid.content.Intent;
+				public describeContents(): number;
+				public constructor(resultCode: number, data: globalAndroid.content.Intent);
+				public writeToParcel(dest: globalAndroid.os.Parcel, flags: number): void;
+				public constructor(parcel: globalAndroid.os.Parcel);
+				public toString(): string;
+				public static resultCodeToString(resultCode: number): string;
+				public getResultCode(): number;
+			}
+			export module ActivityResult {
+				export class Companion {
+					public static class: java.lang.Class<androidx.activity.result.ActivityResult.Companion>;
+					public resultCodeToString(resultCode: number): string;
+				}
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export class ActivityResultCallback<O> extends java.lang.Object {
+				public static class: java.lang.Class<androidx.activity.result.ActivityResultCallback<any>>;
+				/**
+				 * Constructs a new instance of the androidx.activity.result.ActivityResultCallback<any> interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: { onActivityResult(param0: O): void });
+				public constructor();
+				public onActivityResult(param0: O): void;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export class ActivityResultCaller {
+				public static class: java.lang.Class<androidx.activity.result.ActivityResultCaller>;
+				/**
+				 * Constructs a new instance of the androidx.activity.result.ActivityResultCaller interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: { registerForActivityResult(param0: androidx.activity.result.contract.ActivityResultContract<any, any>, param1: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>; registerForActivityResult(param0: androidx.activity.result.contract.ActivityResultContract<any, any>, param1: androidx.activity.result.ActivityResultRegistry, param2: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any> });
+				public constructor();
+				public registerForActivityResult(param0: androidx.activity.result.contract.ActivityResultContract<any, any>, param1: androidx.activity.result.ActivityResultRegistry, param2: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>;
+				public registerForActivityResult(param0: androidx.activity.result.contract.ActivityResultContract<any, any>, param1: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export class ActivityResultCallerLauncher<I, O> extends androidx.activity.result.ActivityResultLauncher<any> {
+				public static class: java.lang.Class<androidx.activity.result.ActivityResultCallerLauncher<any, any>>;
+				public unregister(): void;
+				public getCallerInput(): any;
+				public constructor(launcher: androidx.activity.result.ActivityResultLauncher<any>, callerContract: androidx.activity.result.contract.ActivityResultContract<any, any>, callerInput: any);
+				public getContract(): androidx.activity.result.contract.ActivityResultContract<any, any>;
+				public launch(input: any, options: androidx.core.app.ActivityOptionsCompat): void;
+				public launch(param0: any, param1: androidx.core.app.ActivityOptionsCompat): void;
+				public getCallerContract(): androidx.activity.result.contract.ActivityResultContract<any, any>;
+				public launch(input: any): void;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export abstract class ActivityResultLauncher<I> extends java.lang.Object {
+				public static class: java.lang.Class<androidx.activity.result.ActivityResultLauncher<any>>;
+				public unregister(): void;
+				public launch(param0: I, param1: androidx.core.app.ActivityOptionsCompat): void;
+				public getContract(): androidx.activity.result.contract.ActivityResultContract<I, any>;
+				public launch(input: I): void;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export abstract class ActivityResultRegistry {
+				public static class: java.lang.Class<androidx.activity.result.ActivityResultRegistry>;
+				public register(pendingResult: string, this_: androidx.activity.result.contract.ActivityResultContract<any, any>, key: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>;
+				public unregister$activity_release(pendingResult: string): void;
+				public register(lifecycle: string, lifecycleContainer: androidx.lifecycle.LifecycleOwner, observer: androidx.activity.result.contract.ActivityResultContract<any, any>, this_: androidx.activity.result.ActivityResultCallback<any>): androidx.activity.result.ActivityResultLauncher<any>;
+				public dispatchResult(this_: number, requestCode: number, resultCode: globalAndroid.content.Intent): boolean;
+				public onLaunch(param0: number, param1: androidx.activity.result.contract.ActivityResultContract<any, any>, param2: any, param3: androidx.core.app.ActivityOptionsCompat): void;
+				public onSaveInstanceState(outState: globalAndroid.os.Bundle): void;
+				public dispatchResult(key: number, callbackAndContract: any): boolean;
+				public onRestoreInstanceState(key: globalAndroid.os.Bundle): void;
+				public constructor();
+			}
+			export module ActivityResultRegistry {
+				export class CallbackAndContract<O> extends java.lang.Object {
+					public static class: java.lang.Class<androidx.activity.result.ActivityResultRegistry.CallbackAndContract<any>>;
+					public constructor(callback: androidx.activity.result.ActivityResultCallback<O>, contract: androidx.activity.result.contract.ActivityResultContract<any, O>);
+					public getCallback(): androidx.activity.result.ActivityResultCallback<O>;
+					public getContract(): androidx.activity.result.contract.ActivityResultContract<any, O>;
+				}
+				export class Companion {
+					public static class: java.lang.Class<androidx.activity.result.ActivityResultRegistry.Companion>;
+				}
+				export class LifecycleContainer {
+					public static class: java.lang.Class<androidx.activity.result.ActivityResultRegistry.LifecycleContainer>;
+					public clearObservers(): void;
+					public constructor(lifecycle: androidx.lifecycle.Lifecycle);
+					public getLifecycle(): androidx.lifecycle.Lifecycle;
+					public addObserver(observer: androidx.lifecycle.LifecycleEventObserver): void;
+				}
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export class ActivityResultRegistryOwner {
+				public static class: java.lang.Class<androidx.activity.result.ActivityResultRegistryOwner>;
+				/**
+				 * Constructs a new instance of the androidx.activity.result.ActivityResultRegistryOwner interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: { getActivityResultRegistry(): androidx.activity.result.ActivityResultRegistry });
+				public constructor();
+				public getActivityResultRegistry(): androidx.activity.result.ActivityResultRegistry;
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export class IntentSenderRequest {
+				public static class: java.lang.Class<androidx.activity.result.IntentSenderRequest>;
+				public static CREATOR: globalAndroid.os.Parcelable.Creator<androidx.activity.result.IntentSenderRequest>;
+				public describeContents(): number;
+				public writeToParcel(dest: globalAndroid.os.Parcel, flags: number): void;
+				public getFlagsValues(): number;
+				public getIntentSender(): globalAndroid.content.IntentSender;
+				public constructor(parcel: globalAndroid.os.Parcel);
+				public constructor(intentSender: globalAndroid.content.IntentSender, fillInIntent: globalAndroid.content.Intent, flagsMask: number, flagsValues: number);
+				public getFillInIntent(): globalAndroid.content.Intent;
+				public getFlagsMask(): number;
+			}
+			export module IntentSenderRequest {
+				export class Builder {
+					public static class: java.lang.Class<androidx.activity.result.IntentSenderRequest.Builder>;
+					public setFillInIntent(fillInIntent: globalAndroid.content.Intent): androidx.activity.result.IntentSenderRequest.Builder;
+					public build(): androidx.activity.result.IntentSenderRequest;
+					public constructor(intentSender: globalAndroid.content.IntentSender);
+					public setFlags(values: number, mask: number): androidx.activity.result.IntentSenderRequest.Builder;
+					public constructor(pendingIntent: globalAndroid.app.PendingIntent);
+				}
+				export module Builder {
+					export class Flag {
+						public static class: java.lang.Class<androidx.activity.result.IntentSenderRequest.Builder.Flag>;
+						/**
+						 * Constructs a new instance of the androidx.activity.result.IntentSenderRequest$Builder$Flag interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+						 */
+						public constructor(implementation: {});
+						public constructor();
+					}
+				}
+				export class Companion {
+					public static class: java.lang.Class<androidx.activity.result.IntentSenderRequest.Companion>;
+				}
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export class PickVisualMediaRequest {
+				public static class: java.lang.Class<androidx.activity.result.PickVisualMediaRequest>;
+				public setMediaType$activity_release(set: androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType): void;
+				public getMediaType(): androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType;
+				public constructor();
+			}
+			export module PickVisualMediaRequest {
+				export class Builder {
+					public static class: java.lang.Class<androidx.activity.result.PickVisualMediaRequest.Builder>;
+					public constructor();
+					public setMediaType(mediaType: androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType): androidx.activity.result.PickVisualMediaRequest.Builder;
+					public build(): androidx.activity.result.PickVisualMediaRequest;
+				}
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export module contract {
+				export abstract class ActivityResultContract<I, O> extends java.lang.Object {
+					public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContract<any, any>>;
+					public constructor();
+					public createIntent(param0: globalAndroid.content.Context, param1: I): globalAndroid.content.Intent;
+					public parseResult(param0: number, param1: globalAndroid.content.Intent): O;
+					public getSynchronousResult(context: globalAndroid.content.Context, input: I): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<O>;
+				}
+				export module ActivityResultContract {
+					export class SynchronousResult<T> extends java.lang.Object {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>>;
+						public getValue(): T;
+						public constructor(value: T);
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module androidx {
+	export module activity {
+		export module result {
+			export module contract {
+				export class ActivityResultContracts {
+					public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts>;
+				}
+				export module ActivityResultContracts {
+					export class CaptureVideo extends androidx.activity.result.contract.ActivityResultContract<globalAndroid.net.Uri, java.lang.Boolean> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.CaptureVideo>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(context: globalAndroid.content.Context, input: globalAndroid.net.Uri): globalAndroid.content.Intent;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public parseResult(resultCode: number, intent: globalAndroid.content.Intent): java.lang.Boolean;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: globalAndroid.net.Uri): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<java.lang.Boolean>;
+					}
+					export class CreateDocument extends androidx.activity.result.contract.ActivityResultContract<string, globalAndroid.net.Uri> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.CreateDocument>;
+						public createIntent(context: globalAndroid.content.Context, input: string): globalAndroid.content.Intent;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public getSynchronousResult(context: globalAndroid.content.Context, input: string): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<globalAndroid.net.Uri>;
+						public constructor(mimeType: string);
+						/** @deprecated */
+						public constructor();
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): globalAndroid.net.Uri;
+					}
+					export class GetContent extends androidx.activity.result.contract.ActivityResultContract<string, globalAndroid.net.Uri> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.GetContent>;
+						public createIntent(context: globalAndroid.content.Context, input: string): globalAndroid.content.Intent;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public getSynchronousResult(context: globalAndroid.content.Context, input: string): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<globalAndroid.net.Uri>;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): globalAndroid.net.Uri;
+					}
+					export class GetMultipleContents extends androidx.activity.result.contract.ActivityResultContract<string, java.util.List<globalAndroid.net.Uri>> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents>;
+						public createIntent(context: globalAndroid.content.Context, input: string): globalAndroid.content.Intent;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): java.util.List<globalAndroid.net.Uri>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: string): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<java.util.List<globalAndroid.net.Uri>>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+					}
+					export module GetMultipleContents {
+						export class Companion {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents.Companion>;
+							public getClipDataUris$activity_release(data: globalAndroid.content.Intent): java.util.List<globalAndroid.net.Uri>;
+						}
+					}
+					export class OpenDocument extends androidx.activity.result.contract.ActivityResultContract<androidNative.Array<string>, globalAndroid.net.Uri> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.OpenDocument>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): globalAndroid.net.Uri;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: androidNative.Array<string>): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<globalAndroid.net.Uri>;
+						public createIntent(context: globalAndroid.content.Context, input: androidNative.Array<string>): globalAndroid.content.Intent;
+					}
+					export class OpenDocumentTree extends androidx.activity.result.contract.ActivityResultContract<globalAndroid.net.Uri, globalAndroid.net.Uri> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public getSynchronousResult(context: globalAndroid.content.Context, input: globalAndroid.net.Uri): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<globalAndroid.net.Uri>;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public createIntent(this_: globalAndroid.content.Context, context: globalAndroid.net.Uri): globalAndroid.content.Intent;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): globalAndroid.net.Uri;
+					}
+					export class OpenMultipleDocuments extends androidx.activity.result.contract.ActivityResultContract<androidNative.Array<string>, java.util.List<globalAndroid.net.Uri>> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.OpenMultipleDocuments>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public getSynchronousResult(context: globalAndroid.content.Context, input: androidNative.Array<string>): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<java.util.List<globalAndroid.net.Uri>>;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): java.util.List<globalAndroid.net.Uri>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public createIntent(context: globalAndroid.content.Context, input: androidNative.Array<string>): globalAndroid.content.Intent;
+					}
+					export class PickContact extends androidx.activity.result.contract.ActivityResultContract<java.lang.Void, globalAndroid.net.Uri> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickContact>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(context: globalAndroid.content.Context, input: java.lang.Void): globalAndroid.content.Intent;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): globalAndroid.net.Uri;
+					}
+					export class PickMultipleVisualMedia extends androidx.activity.result.contract.ActivityResultContract<androidx.activity.result.PickVisualMediaRequest, java.util.List<globalAndroid.net.Uri>> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickMultipleVisualMedia>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public createIntent($i$a$applyActivityResultContracts$PickMultipleVisualMedia$createIntent$1: globalAndroid.content.Context, $this$createIntent_u24lambda_u242: androidx.activity.result.PickVisualMediaRequest): globalAndroid.content.Intent;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): java.util.List<globalAndroid.net.Uri>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: androidx.activity.result.PickVisualMediaRequest): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<java.util.List<globalAndroid.net.Uri>>;
+						public constructor(this_: number);
+					}
+
+					export class PickVisualMedia extends androidx.activity.result.contract.ActivityResultContract<androidx.activity.result.PickVisualMediaRequest, globalAndroid.net.Uri> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia>;
+						public static ACTION_SYSTEM_FALLBACK_PICK_IMAGES: string = 'androidx.activity.result.contract.action.PICK_IMAGES';
+						public static EXTRA_SYSTEM_FALLBACK_PICK_IMAGES_MAX: string = 'androidx.activity.result.contract.extra.PICK_IMAGES_MAX';
+						public static GMS_ACTION_PICK_IMAGES: string = 'com.google.android.gms.provider.action.PICK_IMAGES';
+						public static GMS_EXTRA_PICK_IMAGES_MAX: string = 'com.google.android.gms.provider.extra.PICK_IMAGES_MAX';
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public getSynchronousResult(context: globalAndroid.content.Context, input: androidx.activity.result.PickVisualMediaRequest): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<globalAndroid.net.Uri>;
+						public static isPhotoPickerAvailable(context: globalAndroid.content.Context): boolean;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public static isSystemFallbackPickerAvailable$activity_release(context: globalAndroid.content.Context): boolean;
+						/** @deprecated */
+						public static isPhotoPickerAvailable(): boolean;
+						public static isSystemPickerAvailable$activity_release(): boolean;
+						public createIntent($this$createIntent_u24lambda_u240: globalAndroid.content.Context, $i$a$applyActivityResultContracts$PickVisualMedia$createIntent$2: androidx.activity.result.PickVisualMediaRequest): globalAndroid.content.Intent;
+						public static getSystemFallbackPicker$activity_release(context: globalAndroid.content.Context): globalAndroid.content.pm.ResolveInfo;
+						public static getGmsPicker$activity_release(context: globalAndroid.content.Context): globalAndroid.content.pm.ResolveInfo;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public parseResult(it: number, $i$a$runActivityResultContracts$PickVisualMedia$parseResult$2: globalAndroid.content.Intent): globalAndroid.net.Uri;
+						public static isGmsPickerAvailable$activity_release(context: globalAndroid.content.Context): boolean;
+					}
+					export module PickVisualMedia {
+						export class Companion {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.Companion>;
+							/** @deprecated */
+							public isPhotoPickerAvailable(): boolean;
+							public getGmsPicker$activity_release(context: globalAndroid.content.Context): globalAndroid.content.pm.ResolveInfo;
+							public isGmsPickerAvailable$activity_release(context: globalAndroid.content.Context): boolean;
+							public getVisualMimeType$activity_release(input: androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType): string;
+							public getSystemFallbackPicker$activity_release(context: globalAndroid.content.Context): globalAndroid.content.pm.ResolveInfo;
+							public isPhotoPickerAvailable(context: globalAndroid.content.Context): boolean;
+							public isSystemPickerAvailable$activity_release(): boolean;
+							public isSystemFallbackPickerAvailable$activity_release(context: globalAndroid.content.Context): boolean;
+						}
+						export class ImageAndVideo extends androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageAndVideo>;
+							public static INSTANCE: androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageAndVideo;
+						}
+						export class ImageOnly extends androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly>;
+							public static INSTANCE: androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly;
+						}
+						export class SingleMimeType extends androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.SingleMimeType>;
+							public getMimeType(): string;
+							public constructor(mimeType: string);
+						}
+						export class VideoOnly extends androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VideoOnly>;
+							public static INSTANCE: androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VideoOnly;
+						}
+						export class VisualMediaType {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType>;
+							/**
+							 * Constructs a new instance of the androidx.activity.result.contract.ActivityResultContracts$PickVisualMedia$VisualMediaType interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+							 */
+							public constructor(implementation: {});
+							public constructor();
+						}
+					}
+					export class RequestMultiplePermissions extends androidx.activity.result.contract.ActivityResultContract<androidNative.Array<string>, java.util.Map<string, java.lang.Boolean>> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions>;
+						public static ACTION_REQUEST_PERMISSIONS: string = 'androidx.activity.result.contract.action.REQUEST_PERMISSIONS';
+						public static EXTRA_PERMISSIONS: string = 'androidx.activity.result.contract.extra.PERMISSIONS';
+						public static EXTRA_PERMISSION_GRANT_RESULTS: string = 'androidx.activity.result.contract.extra.PERMISSION_GRANT_RESULTS';
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public getSynchronousResult(permission: globalAndroid.content.Context, element$iv: androidNative.Array<string>): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<java.util.Map<string, java.lang.Boolean>>;
+						public parseResult(result: number, item$iv$iv: globalAndroid.content.Intent): java.util.Map<string, java.lang.Boolean>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public createIntent(context: globalAndroid.content.Context, input: androidNative.Array<string>): globalAndroid.content.Intent;
+					}
+					export module RequestMultiplePermissions {
+						export class Companion {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions.Companion>;
+							public createIntent$activity_release(input: androidNative.Array<string>): globalAndroid.content.Intent;
+						}
+					}
+					export class RequestPermission extends androidx.activity.result.contract.ActivityResultContract<string, java.lang.Boolean> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.RequestPermission>;
+						public createIntent(context: globalAndroid.content.Context, input: string): globalAndroid.content.Intent;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public parseResult(result: number, element$iv: globalAndroid.content.Intent): java.lang.Boolean;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public getSynchronousResult(this_: globalAndroid.content.Context, context: string): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<java.lang.Boolean>;
+					}
+					export class StartActivityForResult extends androidx.activity.result.contract.ActivityResultContract<globalAndroid.content.Intent, androidx.activity.result.ActivityResult> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult>;
+						public static EXTRA_ACTIVITY_OPTIONS_BUNDLE: string = 'androidx.activity.result.contract.extra.ACTIVITY_OPTIONS_BUNDLE';
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public parseResult(resultCode: number, intent: globalAndroid.content.Intent): androidx.activity.result.ActivityResult;
+						public constructor();
+						public createIntent(context: globalAndroid.content.Context, input: globalAndroid.content.Intent): globalAndroid.content.Intent;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+					}
+					export module StartActivityForResult {
+						export class Companion {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult.Companion>;
+						}
+					}
+					export class StartIntentSenderForResult extends androidx.activity.result.contract.ActivityResultContract<androidx.activity.result.IntentSenderRequest, androidx.activity.result.ActivityResult> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult>;
+						public static ACTION_INTENT_SENDER_REQUEST: string = 'androidx.activity.result.contract.action.INTENT_SENDER_REQUEST';
+						public static EXTRA_INTENT_SENDER_REQUEST: string = 'androidx.activity.result.contract.extra.INTENT_SENDER_REQUEST';
+						public static EXTRA_SEND_INTENT_EXCEPTION: string = 'androidx.activity.result.contract.extra.SEND_INTENT_EXCEPTION';
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public parseResult(resultCode: number, intent: globalAndroid.content.Intent): androidx.activity.result.ActivityResult;
+						public constructor();
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public createIntent(context: globalAndroid.content.Context, input: androidx.activity.result.IntentSenderRequest): globalAndroid.content.Intent;
+					}
+					export module StartIntentSenderForResult {
+						export class Companion {
+							public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.Companion>;
+						}
+					}
+					export class TakePicture extends androidx.activity.result.contract.ActivityResultContract<globalAndroid.net.Uri, java.lang.Boolean> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.TakePicture>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(context: globalAndroid.content.Context, input: globalAndroid.net.Uri): globalAndroid.content.Intent;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public parseResult(resultCode: number, intent: globalAndroid.content.Intent): java.lang.Boolean;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: globalAndroid.net.Uri): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<java.lang.Boolean>;
+					}
+					export class TakePicturePreview extends androidx.activity.result.contract.ActivityResultContract<java.lang.Void, globalAndroid.graphics.Bitmap> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.TakePicturePreview>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(context: globalAndroid.content.Context, input: java.lang.Void): globalAndroid.content.Intent;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): globalAndroid.graphics.Bitmap;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: java.lang.Void): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<globalAndroid.graphics.Bitmap>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+					}
+					export class TakeVideo extends androidx.activity.result.contract.ActivityResultContract<globalAndroid.net.Uri, globalAndroid.graphics.Bitmap> {
+						public static class: java.lang.Class<androidx.activity.result.contract.ActivityResultContracts.TakeVideo>;
+						public parseResult(param0: number, param1: globalAndroid.content.Intent): any;
+						public constructor();
+						public createIntent(context: globalAndroid.content.Context, input: globalAndroid.net.Uri): globalAndroid.content.Intent;
+						public parseResult(it: number, this_: globalAndroid.content.Intent): globalAndroid.graphics.Bitmap;
+						public createIntent(param0: globalAndroid.content.Context, param1: any): globalAndroid.content.Intent;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: any): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<any>;
+						public getSynchronousResult(context: globalAndroid.content.Context, input: globalAndroid.net.Uri): androidx.activity.result.contract.ActivityResultContract.SynchronousResult<globalAndroid.graphics.Bitmap>;
+					}
+				}
+			}
+		}
+	}
+}
+
+//Generics information:
+//androidx.activity.result.ActivityResultCallback:1
+//androidx.activity.result.ActivityResultCallerLauncher:2
+//androidx.activity.result.ActivityResultLauncher:1
+//androidx.activity.result.ActivityResultRegistry.CallbackAndContract:1
+//androidx.activity.result.contract.ActivityResultContract:2
+//androidx.activity.result.contract.ActivityResultContract.SynchronousResult:1

--- a/tools/assets/App_Resources/Android/app.gradle
+++ b/tools/assets/App_Resources/Android/app.gradle
@@ -31,11 +31,11 @@ dependencies {
 }
 
 android {  
-  compileSdkVersion 33
-  buildToolsVersion "33.0.0"
+  compileSdkVersion 34
+  buildToolsVersion "34.0.0"
   defaultConfig {  
     minSdkVersion 24
-    targetSdkVersion 33
+    targetSdkVersion 34
     generatedDensities = []
   }  
   aaptOptions {  

--- a/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
@@ -19,8 +19,6 @@
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<uses-permission android:name="android.permission.WRITE_CONTACTS" />
 	<uses-permission android:name="android.permission.GLOBAL_SEARCH" />
-	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
 	<application
 		android:name="com.tns.NativeScriptApplication"

--- a/tools/demo/imagepicker/index.ts
+++ b/tools/demo/imagepicker/index.ts
@@ -67,6 +67,7 @@ export class DemoSharedImagepicker extends DemoSharedBase {
 			mediaType: imagepicker.ImagePickerMediaType.Any,
 			copyToAppFolder: 'media',
 			renameFileTo: 'foobarmultiple',
+			android: { use_photo_picker: true },
 		});
 		this.startSelection(context);
 	}
@@ -78,6 +79,7 @@ export class DemoSharedImagepicker extends DemoSharedBase {
 			mediaType: imagepicker.ImagePickerMediaType.Any,
 			copyToAppFolder: 'media',
 			renameFileTo: 'foobar',
+			android: { use_photo_picker: true },
 		});
 		this.startSelection(context);
 	}

--- a/tools/demo/imagepicker/index.ts
+++ b/tools/demo/imagepicker/index.ts
@@ -68,6 +68,7 @@ export class DemoSharedImagepicker extends DemoSharedBase {
 			copyToAppFolder: 'media',
 			renameFileTo: 'foobarmultiple',
 			android: { use_photo_picker: true },
+			maximumNumberOfSelection: 2,
 		});
 		this.startSelection(context);
 	}


### PR DESCRIPTION
As raised in Issue: #605 Google is enforcing policies around the usage of the `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions.

More details are available [here](https://support.google.com/googleplay/android-developer/answer/14115180?hl=en).

This PR allows the caller to specify that they want to use the [Photo Picker](https://developer.android.com/training/data-storage/shared/photopicker).

If the phone is running Android 13 or above it uses the Photo Picker, otherwise it proceeds as before ( this avoids the complexity around the back porting scenario).