### PR TITLE
fix(camera): handle permissions in the same way in iOS and Android

### DIFF
--- a/packages/camera/README.md
+++ b/packages/camera/README.md
@@ -18,6 +18,10 @@
 
 A plugin that allows you to take a picture and optionally save it on the device storage.
 
+**Note: Version 7 contains breaking changes:**
+* New behavior on requesting permissions, detailed in [Request for user permissions](#request-for-user-permissions).
+
+
 ## Installation
 
 To install the plugin, run the following command in the root directory of your project:
@@ -54,17 +58,38 @@ To prompt the user to grant or deny your app access to their camera and photo ga
 ```TypeScript
 import { requestPermissions } from '@nativescript/camera';
 
-requestPermissions().then(
-    function success() {
-        // permission request accepted or already granted
-        // ... call camera.takePicture here ...
-    },
-    function failure() {
-        // permission request rejected
-        // ... tell the user ...
-    }
-);
+const perms = await camera.requestPermissions();
+
+if (perms.Success) {
+     // permission request accepted or already granted
+     // ... call camera.takePicture here ...
+} else {
+     // permission request rejected
+     // ... tell the user ...
+     const cameraPermissionSuccess = perms.Details.Camera.Success;
+     const photoPermissionSuccess = perms.Details.Photo.Success
+}
+
 ```
+
+If specifying the `saveToGallery = false` option, you can call the `requestCameraPermissions` method.
+
+```TypeScript
+import { requestPermissions } from '@nativescript/camera';
+
+const perms = await camera.requestCameraPermissions();
+
+if (perms.Success) {
+     // permission request accepted or already granted
+     // ... call camera.takePicture here ...
+} else {
+     // permission request rejected
+     // ... tell the user ...
+     
+}
+
+```
+
 > **Note:** (**for Android**) Older versions of Android that don't use a request permissions popup won't be affected by the usage of the `requestPermissions()` method.
 
 > **Note**: (**for iOS**) If the user rejects permissions from the iOS popup, the app is not allowed to ask again. You can instruct the user to go to app settings and enable the camera permission manually from there. 

--- a/packages/camera/common.ts
+++ b/packages/camera/common.ts
@@ -1,11 +1,81 @@
+import * as permissions from '@nativescript-community/perms';
 export function getAspectSafeDimensions(sourceWidth, sourceHeight, reqWidth, reqHeight) {
-  let widthCoef = sourceWidth / reqWidth;
-  let heightCoef = sourceHeight / reqHeight;
+	let widthCoef = sourceWidth / reqWidth;
+	let heightCoef = sourceHeight / reqHeight;
 
-  let aspectCoef = widthCoef > heightCoef ? widthCoef : heightCoef;
+	let aspectCoef = widthCoef > heightCoef ? widthCoef : heightCoef;
 
-  return {
-      width: Math.floor(sourceWidth / aspectCoef),
-      height: Math.floor(sourceHeight / aspectCoef)
-  };
+	return {
+		width: Math.floor(sourceWidth / aspectCoef),
+		height: Math.floor(sourceHeight / aspectCoef),
+	};
+}
+function mapStatus(result: permissions.Result): Status {
+	let status = Status.unknown;
+	if (result && result.length > 1) {
+		if (Object.keys(Status).findIndex((k) => k === result[0]) >= 0) {
+			status = Status[result[0]];
+		}
+	}
+	return status;
+}
+export function mapError(e): PermissionResult {
+	return {
+		Success: false,
+		Details: Status.error,
+		Error: e,
+	};
+}
+export function mapCameraPermissionStatus(permission: permissions.Result): PermissionResult {
+	const status = mapStatus(permission);
+	const result = {
+		Success: status === Status.authorized,
+		Details: status,
+	};
+	return result;
+}
+
+export function mapPhotoPermissionStatus(permission: permissions.Result): PermissionResult {
+	const status = mapStatus(permission);
+	const result = {
+		Success: status === Status.authorized || status === Status.limited,
+		Details: status,
+	};
+	return result;
+}
+
+export function combineCamerPhotoPermissions(cameraPermissions: PermissionResult, photoPermissions: PermissionResult): PermissionsResult {
+	const result = {
+		Success: cameraPermissions.Success && photoPermissions.Success,
+		Details: {
+			Camera: cameraPermissions,
+			Photo: photoPermissions,
+		},
+	};
+	return result;
+}
+
+export enum Status {
+	authorized = 'authorized',
+	denied = 'denied',
+	limited = 'limited',
+	restricted = 'restricted',
+	undetermined = 'undetermined',
+	never_ask_again = 'never_ask_again',
+	unknown = 'unknown',
+	error = 'error',
+}
+
+export interface PermissionsResult {
+	Success: boolean;
+	Details: {
+		Camera?: PermissionResult;
+		Photo?: PermissionResult;
+	};
+}
+
+export interface PermissionResult {
+	Success: boolean;
+	Details: Status;
+	Error?: any;
 }

--- a/packages/camera/index.d.ts
+++ b/packages/camera/index.d.ts
@@ -1,5 +1,5 @@
 import { ImageAsset } from '@nativescript/core';
-
+import { PermissionsResult, PermissionResult } from './common';
 /**
  * Take a photo using the camera.
  * @param options - Optional parameter for setting different camera options.
@@ -9,9 +9,9 @@ export function takePicture(options?: CameraOptions): Promise<ImageAsset>;
 /**
  * Check required permissions for using device camera.
  */
-export function requestPermissions(): Promise<any>;
-export function requestCameraPermissions(): Promise<any>;
-export function requestPhotosPermissions(): Promise<any>;
+export function requestPermissions(): Promise<PermissionsResult>;
+export function requestCameraPermissions(): Promise<PermissionResult>;
+export function requestPhotosPermissions(): Promise<PermissionResult>;
 
 /**
  * Is the camera available to use
@@ -19,46 +19,45 @@ export function requestPhotosPermissions(): Promise<any>;
 export function isAvailable(): Boolean;
 
 export interface CameraOptions {
-    /**
-     * Defines the desired width (in device independent pixels) of the taken image. It should be used with height property.
-     * If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image.
-     * The actual image width will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions).
-     */
-    width?: number;
+	/**
+	 * Defines the desired width (in device independent pixels) of the taken image. It should be used with height property.
+	 * If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image.
+	 * The actual image width will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions).
+	 */
+	width?: number;
 
-    /**
-     * Defines the desired height (in device independent pixels) of the taken image. It should be used with width property.
-     * If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image.
-     * The actual image height will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions).
-     */
-    height?: number;
+	/**
+	 * Defines the desired height (in device independent pixels) of the taken image. It should be used with width property.
+	 * If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image.
+	 * The actual image height will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions).
+	 */
+	height?: number;
 
-    /**
-     * Defines if camera picture aspect ratio should be kept during picture resizing.
-     * This property could affect width or height return values.
-     */
-    keepAspectRatio?: boolean;
+	/**
+	 * Defines if camera picture aspect ratio should be kept during picture resizing.
+	 * This property could affect width or height return values.
+	 */
+	keepAspectRatio?: boolean;
 
-    /**
-     * Defines if camera picture should be copied to photo Gallery (Android) or Photos (iOS)
-     */
-    saveToGallery?: boolean;
+	/**
+	 * Defines if camera picture should be copied to photo Gallery (Android) or Photos (iOS)
+	 */
+	saveToGallery?: boolean;
 
-    /**
-     * iOS Only
-     * Defines if camera "Retake" or "Use Photo" screen forces user to crop camera picture to a square and optionally lets them zoom in.
-     */
-    allowsEditing?: boolean;
+	/**
+	 * iOS Only
+	 * Defines if camera "Retake" or "Use Photo" screen forces user to crop camera picture to a square and optionally lets them zoom in.
+	 */
+	allowsEditing?: boolean;
 
-    /**
-     * The initial camera. Default "rear".
-     * The current implementation doesn't work on all Android devices, in which case it falls back to the default behavior.
-     */
-    cameraFacing?: "front" | "rear";
+	/**
+	 * The initial camera. Default "rear".
+	 * The current implementation doesn't work on all Android devices, in which case it falls back to the default behavior.
+	 */
+	cameraFacing?: 'front' | 'rear';
 
-
-    /**
-     * (iOS Only) Specify a custom UIModalPresentationStyle (Defaults to UIModalPresentationStyle.FullScreen)
-     */
-     modalPresentationStyle?: number;
+	/**
+	 * (iOS Only) Specify a custom UIModalPresentationStyle (Defaults to UIModalPresentationStyle.FullScreen)
+	 */
+	modalPresentationStyle?: number;
 }

--- a/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/tools/assets/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
 		android:normalScreens="true"
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
-
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>  
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/tools/demo/camera/index.ts
+++ b/tools/demo/camera/index.ts
@@ -5,15 +5,15 @@ import { DemoSharedBase } from '../utils';
 export class DemoSharedCamera extends DemoSharedBase {
 	picturePath: string;
 	cameraImage: any;
-	saveToGallery: false;
-	allowsEditing: false;
-	keepAspectRatio: true;
-	width: 320;
-	height: 240;
+	saveToGallery = false;
+	allowsEditing = false;
+	keepAspectRatio = true;
+	width = 320;
+	height = 240;
 
 	onTakePictureTap(args: EventData) {
-		requestPermissions().then(
-			() => {
+		requestPermissions().then((perms) => {
+			if (perms.Success) {
 				takePicture({ width: this.width, height: this.height, keepAspectRatio: this.keepAspectRatio, saveToGallery: this.saveToGallery, allowsEditing: this.allowsEditing }).then(
 					(imageAsset: ImageAsset) => {
 						this.set('cameraImage', imageAsset);
@@ -41,8 +41,9 @@ export class DemoSharedCamera extends DemoSharedBase {
 						console.log('Error -> ' + err.message);
 					}
 				);
-			},
-			() => Dialogs.alert('permissions rejected')
-		);
+			} else {
+				Dialogs.alert(`permissions rejected: camera ${perms.Details.Camera?.Success}, photo ${perms.Details.Photo?.Success}`);
+			}
+		});
 	}
 }


### PR DESCRIPTION
Previously IOS threw exceptions and android returned a result indicating failure.

Now both return a result indicating any errors, and which permissions failed.