### PR TITLE
[@nativescript/google-signin] iOS: Bump Google Sign-In pod version

### DIFF
--- a/packages/google-signin/platforms/ios/Podfile
+++ b/packages/google-signin/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'GoogleSignIn', '~> 7.0'
+pod 'GoogleSignIn', '~> 8.0'

--- a/packages/google-signin/platforms/ios/Podfile
+++ b/packages/google-signin/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'GoogleSignIn', '~> 8.0'
+pod 'GoogleSignIn', '~> 7.1'


### PR DESCRIPTION
Recent Apple privacy manifests requirement requires all 3rd party packages to have it and is a cause of App Store rejections, therefore it's not possible to upload builds with this package.

Changed the version to v7.1.0 (https://github.com/google/GoogleSignIn-iOS/releases/tag/7.1.0)
Although version 8.0 is available, it may not be compatible with current NS google packages (firebase etc)