### PR TITLE
feat(facebook): add authenticationToken to LoginResult

### DIFF
--- a/packages/facebook/common.ts
+++ b/packages/facebook/common.ts
@@ -26,6 +26,14 @@ export interface IAccessToken {
 	readonly userID: string;
 }
 
+export interface IAuthenticationToken {
+	readonly graphDomain: string;
+
+	readonly nonce: string;
+
+	readonly tokenString: string;
+}
+
 export interface ILoginResult {
 	readonly declinedPermissions: string[];
 
@@ -34,4 +42,6 @@ export interface ILoginResult {
 	readonly isCancelled: boolean;
 
 	readonly token: IAccessToken;
+
+	readonly authenticationToken: IAuthenticationToken;
 }

--- a/packages/facebook/index.android.ts
+++ b/packages/facebook/index.android.ts
@@ -145,16 +145,57 @@ export class AccessToken {
 	}
 }
 
+export class AuthenticationToken {
+	#native: com.facebook.AuthenticationToken;
+
+	static fromNative(authenticationToken: com.facebook.AuthenticationToken) {
+		if (authenticationToken instanceof com.facebook.AuthenticationToken) {
+			const token = new AuthenticationToken();
+			token.#native = authenticationToken;
+			return token;
+		}
+		return null;
+	}
+
+	get nonce(): string {
+		return this.native.getExpectedNonce();
+	}
+
+	get tokenString(): string {
+		return this.native.getToken();
+	}
+
+	static currentAuthenticationToken(): AuthenticationToken {
+		return AuthenticationToken.fromNative(com.facebook.AuthenticationToken.getCurrentAuthenticationToken());
+	}
+
+	toJSON() {
+		return {
+			nonce: this.nonce,
+			tokenString: this.tokenString,
+		};
+	}
+
+	get native() {
+		return this.#native;
+	}
+
+	get android() {
+		return this.native;
+	}
+}
+
 export class LoginResult {
 	#native: com.facebook.login.LoginResult;
 	#token: AccessToken;
+	#authenticationToken: AuthenticationToken;
 	#declinedPermissions: string[];
 	#grantedPermissions: string[];
 	#isCancelled = false;
-	static fromNative(logingResult: com.facebook.login.LoginResult) {
-		if (logingResult instanceof com.facebook.login.LoginResult) {
+	static fromNative(loginResult: com.facebook.login.LoginResult) {
+		if (loginResult instanceof com.facebook.login.LoginResult) {
 			const result = new LoginResult();
-			result.#native = logingResult;
+			result.#native = loginResult;
 			return result;
 		}
 		return null;
@@ -200,12 +241,20 @@ export class LoginResult {
 		return this.#token;
 	}
 
+	get authenticationToken(): AuthenticationToken {
+		if (!this.#authenticationToken) {
+			this.#authenticationToken = AuthenticationToken.fromNative(this.native.getAuthenticationToken());
+		}
+		return this.#authenticationToken;
+	}
+
 	toJSON() {
 		return {
 			declinedPermissions: this.declinedPermissions,
 			grantedPermissions: this.grantedPermissions,
 			isCancelled: this.isCancelled,
 			token: this.token,
+			authenticationToken: this.authenticationToken,
 		};
 	}
 
@@ -252,7 +301,7 @@ export class LoginManager implements ILoginManager {
 					onError(param0: com.facebook.FacebookException) {
 						reject(FacebookError.fromNative(param0 as any));
 					},
-				})
+				}),
 			);
 			this.#native.logIn(<android.app.Activity>context || Application.android.foregroundActivity || Application.android.startActivity, java.util.Arrays.asList(permissions));
 		});

--- a/packages/facebook/index.d.ts
+++ b/packages/facebook/index.d.ts
@@ -1,4 +1,4 @@
-import { IAccessToken, ILoginResult } from './common';
+import { IAccessToken, IAuthenticationToken, ILoginResult } from './common';
 export declare class FacebookError extends Error {
 	readonly native: any;
 }
@@ -39,6 +39,22 @@ export declare class AccessToken implements IAccessToken {
 	readonly ios;
 }
 
+export declare class AuthenticationToken implements IAuthenticationToken {
+	readonly graphDomain: string;
+
+	readonly tokenString: string;
+
+	readonly nonce: string;
+
+	static currentAuthenticationToken(): AuthenticationToken;
+
+	readonly native;
+
+	readonly android;
+
+	readonly ios;
+}
+
 export declare class LoginResult implements ILoginResult {
 	readonly declinedPermissions: string[];
 
@@ -47,6 +63,8 @@ export declare class LoginResult implements ILoginResult {
 	readonly isCancelled: boolean;
 
 	readonly token: AccessToken;
+
+	readonly authenticationToken: AuthenticationToken;
 
 	readonly native;
 

--- a/packages/facebook/index.ios.ts
+++ b/packages/facebook/index.ios.ts
@@ -141,7 +141,7 @@ export class AuthenticationToken {
 	}
 
 	get graphDomain(): string {
-		return FBSDKAuthenticationToken.tokenCache.authenticationToken.graphDomain;
+		return FBSDKAuthenticationToken.tokenCache?.authenticationToken?.graphDomain;
 	}
 
 	get nonce(): string {

--- a/packages/facebook/index.ios.ts
+++ b/packages/facebook/index.ios.ts
@@ -128,16 +128,62 @@ export class AccessToken {
 	}
 }
 
+export class AuthenticationToken {
+	#native: FBSDKAuthenticationToken;
+
+	static fromNative(authenticationToken: FBSDKAuthenticationToken) {
+		if (authenticationToken instanceof FBSDKAuthenticationToken) {
+			const token = new AuthenticationToken();
+			token.#native = authenticationToken;
+			return token;
+		}
+		return null;
+	}
+
+	get graphDomain(): string {
+		return FBSDKAuthenticationToken.tokenCache.authenticationToken.graphDomain;
+	}
+
+	get nonce(): string {
+		return this.native.nonce;
+	}
+
+	get tokenString(): string {
+		return this.native.tokenString;
+	}
+
+	static currentAuthenticationToken(): AuthenticationToken {
+		return AuthenticationToken.fromNative(FBSDKAuthenticationToken.currentAuthenticationToken);
+	}
+
+	toJSON() {
+		return {
+			graphDomain: this.graphDomain,
+			nonce: this.nonce,
+			tokenString: this.tokenString,
+		};
+	}
+
+	get native() {
+		return this.#native;
+	}
+
+	get ios() {
+		return this.native;
+	}
+}
+
 export class LoginResult {
 	#native: FBSDKLoginManagerLoginResult;
 	#token: AccessToken;
+	#authenticationToken: AuthenticationToken;
 	#declinedPermissions: string[];
 	#grantedPermissions: string[];
 
-	static fromNative(logingResult: FBSDKLoginManagerLoginResult) {
-		if (logingResult instanceof FBSDKLoginManagerLoginResult) {
+	static fromNative(loginResult: FBSDKLoginManagerLoginResult) {
+		if (loginResult instanceof FBSDKLoginManagerLoginResult) {
 			const result = new LoginResult();
-			result.#native = logingResult;
+			result.#native = loginResult;
 			return result;
 		}
 		return null;
@@ -168,12 +214,20 @@ export class LoginResult {
 		return this.#token;
 	}
 
+	get authenticationToken(): AuthenticationToken {
+		if (!this.#authenticationToken) {
+			this.#authenticationToken = AuthenticationToken.fromNative(this.native.authenticationToken);
+		}
+		return this.#authenticationToken;
+	}
+
 	toJSON() {
 		return {
 			declinedPermissions: this.declinedPermissions,
 			grantedPermissions: this.grantedPermissions,
 			isCancelled: this.isCancelled,
 			token: this.token,
+			authenticationToken: this.authenticationToken,
 		};
 	}
 


### PR DESCRIPTION
The Facebook iOS SDK no longer provides valid user access tokens in scenarios where the user opts out of ATT. The access token validation or Graph API requests may throw errors like OAuthException - “Invalid OAuth access token - Cannot parse access token”. Developers are recommended to integrate "Facebook Limited Login" and therefore, the LoginResult within  this plugin needs to contain the authenticationToken provided by the iOS SDK.

See 
https://github.com/facebook/facebook-ios-sdk/issues/2400#issuecomment-2080023795
https://developers.facebook.com/docs/facebook-login/limited-login/ios