### PR TITLE
Update permission dependency and simplify authorization check

### DIFF
--- a/packages/local-notifications/index.android.ts
+++ b/packages/local-notifications/index.android.ts
@@ -121,7 +121,7 @@ export class LocalNotificationsImpl extends LocalNotificationsCommon implements 
 						success: (notification) => {
 							onReceived(JSON.parse(notification));
 						},
-					})
+					}),
 				);
 				resolve();
 			} catch (ex) {
@@ -140,7 +140,7 @@ export class LocalNotificationsImpl extends LocalNotificationsCommon implements 
 						success: (notification) => {
 							onReceived(JSON.parse(notification));
 						},
-					})
+					}),
 				);
 				resolve();
 			} catch (ex) {
@@ -295,7 +295,7 @@ export class LocalNotificationsImpl extends LocalNotificationsCommon implements 
 		}
 	}
 
-	private static isAuthorized(result: Result): boolean {
+	private static isAuthorized(result: Result<'notification'>): boolean {
 		return result === 'authorized';
 	}
 }

--- a/packages/local-notifications/index.android.ts
+++ b/packages/local-notifications/index.android.ts
@@ -296,8 +296,7 @@ export class LocalNotificationsImpl extends LocalNotificationsCommon implements 
 	}
 
 	private static isAuthorized(result: Result): boolean {
-		const [status, _] = result;
-		return status === 'authorized';
+		return result === 'authorized';
 	}
 }
 

--- a/packages/local-notifications/package.json
+++ b/packages/local-notifications/package.json
@@ -46,6 +46,6 @@
 	"homepage": "https://github.com/nativescript/plugins",
 	"dependencies": {
 		"@nativescript/shared-notification-delegate": "~1.0.0",
-		"@nativescript-community/perms": "^2.3.0"
+		"@nativescript-community/perms": "^3.0.4"
 	}
 }


### PR DESCRIPTION
Upgrade the permission dependency to version ^3.0.4 and streamline the authorization check logic for improved clarity.