### PR TITLE
fix(secure-store): 16kb support

### DIFF
--- a/packages/secure-storage/platforms/android/include.gradle
+++ b/packages/secure-storage/platforms/android/include.gradle
@@ -1,7 +1,8 @@
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
-    implementation 'com.orhanobut:hawk:2.0.1'
+    implementation 'com.github.triniwiz:hawk:712a481082'
 }


### PR DESCRIPTION
Uses an updated build with 16kb support enabled, builds are done using jitpack

https://github.com/triniwiz/conceal
https://github.com/triniwiz/hawk