### PR TITLE
fix(google-signin): return tokenString instead of GIDToken object on iOS

### DIFF
--- a/packages/google-signin/CHANGELOG.md
+++ b/packages/google-signin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2 (2025-11-21)
+
+### 🩹 Fixes
+ - **google-signin:** iOS getTokens return string token instead `GIDToken` object
+
+
 ## 2.1.1 (2025-03-03)
 
 ### 🚀 Features

--- a/packages/google-signin/index.ios.ts
+++ b/packages/google-signin/index.ios.ts
@@ -207,8 +207,8 @@ export class GoogleSignin {
 					reject(GoogleError.fromNative(error));
 				} else {
 					resolve({
-						idToken: auth?.idToken,
-						accessToken: auth?.accessToken,
+						idToken: auth?.idToken.tokenString,
+						accessToken: auth?.accessToken.tokenString,
 					});
 				}
 			});

--- a/packages/google-signin/package.json
+++ b/packages/google-signin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nativescript/google-signin",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"description": "Google Sign-in for your NativeScript applications",
 	"main": "index",
 	"typings": "index.d.ts",


### PR DESCRIPTION
## Description
Fix iOS token retrieval returning GIDToken object instead of string value.
## Problem
On iOS, `getTokens()` returns native `GIDToken` objects instead of token strings, making the tokens unusable in JavaScript.

## Solution
Use `.tokenString` property from `GIDToken` objects to extract actual token values.

## Testing
- [x] Tested on iOS device iOS 16.7.12 and simulator iOS 17.5 also iOS 18.0 
- [x] Verified tokens are now strings
- [x] Sign-in flow works correctly sending token to BE

## Platforms affected
- [x] iOS
- [ ] Android