### PR TITLE
fix(apple-sign-in): return identityToken, authorizationCode as String not native iOS Object 

### DIFF
--- a/packages/apple-sign-in/CHANGELOG.md
+++ b/packages/apple-sign-in/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 1.0.1 (2025-11-21)
+
+### 🩹 Fixes
+ - **apple-sign-in:** iOS identityToken and authorizationCode return string instead object

--- a/packages/apple-sign-in/index.ios.ts
+++ b/packages/apple-sign-in/index.ios.ts
@@ -222,14 +222,14 @@ function ensureClass() {
             const identityTokenData = credential.valueForKey('identityToken');
 
             if (identityTokenData) {
-                identityToken = NSString.alloc().initWithDataEncoding(identityTokenData, NSUTF8StringEncoding);
+                identityToken = NSString.alloc().initWithDataEncoding(identityTokenData, NSUTF8StringEncoding).toString();
             }
 
             let authorizationCode = null;
             const authorizationCodeData = credential.valueForKey('authorizationCode');
 
             if (authorizationCodeData) {
-                authorizationCode = NSString.alloc().initWithDataEncoding(authorizationCodeData, NSUTF8StringEncoding);
+                authorizationCode = NSString.alloc().initWithDataEncoding(authorizationCodeData, NSUTF8StringEncoding).toString();
             }
 
             let fullName: UserFullName = null;

--- a/packages/apple-sign-in/package.json
+++ b/packages/apple-sign-in/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nativescript/apple-sign-in",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Sign In With Apple",
 	"main": "index",
 	"typings": "index.d.ts",


### PR DESCRIPTION
## Description
Fix iOS  identityToken, authorizationCode returning native object instead of string value.

## Problem
On iOS,  SignIn.signIn(options) returns identityToken, authorizationCode object instead of strings.
typeof identityToken is object not a string and should be converted before used in BE
typeof authorizationCode is object not a string and should be converted before used in BE

## Solution
Use .toString() method after decoding data

## Testing
- [x] Tested on iOS device iOS 16.7.12 and simulator iOS 17.5 also iOS 18.0 
- [x] Verified identityToken, authorizationCode  are now JavaScripts strings
- [x] Sign-in flow works correctly sending token to BE

## Platforms affected
- [x] iOS
- [ ] Android