### PR TITLE
feat: input accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [@nativescript/google-signin](packages/google-signin/README.md)
 - [@nativescript/haptics](packages/haptics/README.md)
 - [@nativescript/imagepicker](packages/imagepicker/README.md)
+- [@nativescript/input-accessory](packages/input-accessory/README.md)
 - [@nativescript/ios-security](packages/ios-security/README.md)
 - [@nativescript/iqkeyboardmanager](packages/iqkeyboardmanager/README.md)
 - [@nativescript/keyboard-toolbar](packages/keyboard-toolbar/README.md)

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -4,9 +4,8 @@
 	"license": "SEE LICENSE IN <your-license-filename>",
 	"repository": "<fill-your-repository-here>",
 	"dependencies": {
-		"@nativescript/google-maps": "file:../../packages/google-maps",
-		"@nativescript/core": "*",
-		"@nativescript/google-maps-utils": "file:../../packages/google-maps-utils",
+		"@nativescript/core": "file:../../node_modules/@nativescript/core",
+		"@nativescript/input-accessory": "file:../../packages/input-accessory",
 		"@nativescript/animated-circle": "file:../../packages/animated-circle",
 		"@nativescript/appavailability": "file:../../packages/appavailability",
 		"@nativescript/apple-sign-in": "file:../../packages/apple-sign-in",
@@ -25,6 +24,8 @@
 		"@nativescript/facebook": "file:../../packages/facebook",
 		"@nativescript/fingerprint-auth": "file:../../packages/fingerprint-auth",
 		"@nativescript/geolocation": "file:../../packages/geolocation",
+		"@nativescript/google-maps": "file:../../packages/google-maps",
+		"@nativescript/google-maps-utils": "file:../../packages/google-maps-utils",
 		"@nativescript/google-mobile-ads": "file:../../packages/google-mobile-ads",
 		"@nativescript/google-signin": "file:../../packages/google-signin",
 		"@nativescript/haptics": "file:../../packages/haptics",
@@ -44,8 +45,8 @@
 		"@nativescript/zip": "file:../../packages/zip"
 	},
 	"devDependencies": {
-		"@nativescript/android": "~8.9.0",
-		"@nativescript/ios": "~8.9.0",
+		"@nativescript/android": "~9.0.0",
+		"@nativescript/ios": "~9.0.0",
 		"@nativescript/tailwind": "~2.1.0",
 		"tailwindcss": "~3.4.0"
 	}

--- a/apps/demo/project.json
+++ b/apps/demo/project.json
@@ -36,7 +36,8 @@
 				"uglify": false,
 				"release": false,
 				"forDevice": false,
-				"prepare": false
+				"prepare": false,
+				"flags": "--env.commonjs"
 			}
 		}
 	}

--- a/apps/demo/src/main-page.xml
+++ b/apps/demo/src/main-page.xml
@@ -28,6 +28,7 @@
       <Button text="google-signin" tap="{{ viewDemo }}" class="bg-blue-500 rounded-full text-white p-4 mb-4"/>
       <Button text="haptics" tap="{{ viewDemo }}" class="bg-blue-500 rounded-full text-white p-4 mb-4"/>
       <Button text="imagepicker" tap="{{ viewDemo }}" class="bg-blue-500 rounded-full text-white p-4 mb-4"/>
+      <Button text="input-accessory" tap="{{ viewDemo }}" class="bg-blue-500 rounded-full text-white p-4 mb-4"/>
       <Button text="ios-security" tap="{{ viewDemo }}" class="bg-blue-500 rounded-full text-white p-4 mb-4"/>
       <Button text="iqkeyboardmanager" tap="{{ viewDemo }}" class="bg-blue-500 rounded-full text-white p-4 mb-4"/>
       <Button text="keyboard-toolbar" tap="{{ viewDemo }}" class="bg-blue-500 rounded-full text-white p-4 mb-4"/>

--- a/apps/demo/src/plugin-demos/input-accessory.ts
+++ b/apps/demo/src/plugin-demos/input-accessory.ts
@@ -1,0 +1,117 @@
+import { EventData, Page, ScrollView, TextView, View } from '@nativescript/core';
+import { DemoSharedInputAccessory } from '@demo/shared';
+import { InputAccessoryManager } from '@nativescript/input-accessory';
+
+export function navigatingTo(args: EventData) {
+	const page = <Page>args.object;
+	page.bindingContext = new DemoModel(page);
+}
+
+export class DemoModel extends DemoSharedInputAccessory {
+	private accessoryManager: InputAccessoryManager | null = null;
+	private textView: TextView | null = null;
+	private page: Page;
+	private isAccessorySetup = false;
+	private inputText = '';
+
+	constructor(page: Page) {
+		super();
+		this.page = page;
+
+		this.set('inputText', '');
+		this.set('messages', [
+			'Welcome to @nativescript/input-accessory 👋',
+			'Tap in the field below to attach the input to the keyboard.',
+			'Type and press Send to append messages while tracking keyboard transitions.',
+			'Random thought: pineapple absolutely belongs on pizza. 🍍',
+			'Just testing long text wrapping in this message bubble for layout stability.',
+			'Keyboard animation looks smooth on both platforms so far.',
+			'Reminder: drink water and stretch every hour 💧',
+			'If this were a real chat, someone would definitely send a GIF here.',
+			'This plugin is perfect for support chats and comment threads.',
+			'Interactive dismiss feels super natural when dragging the list.',
+			'Quick check-in: are we shipping this in the next release?',
+			'Edge case test: message count should keep scrolling correctly.',
+			'Last seeded message: ready for your own typing test 🚀',
+		]);
+
+		this.page.on(Page.loadedEvent, () => {
+			setTimeout(() => this.setupAccessory(), 100);
+		});
+
+		this.page.on(Page.navigatingFromEvent, () => {
+			this.accessoryManager?.cleanup();
+			this.accessoryManager = null;
+			this.isAccessorySetup = false;
+		});
+	}
+
+	onMessageInputLoaded(args: EventData) {
+		this.textView = args.object as TextView;
+		this.setupAccessory();
+	}
+
+	onMessageTextChange() {
+		this.inputText = this.textView?.text || '';
+		this.accessoryManager?.updateAccessoryHeight();
+	}
+
+	onMessageReturnPress() {
+		this.sendMessage();
+	}
+
+	sendMessage() {
+		const inputText = (this.inputText || '').trim();
+		if (!inputText) {
+			return;
+		}
+
+		this.appendMessage(`You: ${inputText}`);
+		this.set('inputText', '');
+		this.inputText = '';
+	}
+
+	dismissKeyboard() {
+		this.accessoryManager?.dismissKeyboard();
+	}
+
+	private setupAccessory() {
+		if (this.isAccessorySetup || !this.textView) {
+			return;
+		}
+
+		const scrollView = this.page.getViewById<ScrollView>('messagesScrollView');
+		const inputContainer = this.page.getViewById<View>('inputContainer');
+
+		if (!scrollView || !inputContainer) {
+			setTimeout(() => this.setupAccessory(), 100);
+			return;
+		}
+
+		this.accessoryManager = new InputAccessoryManager();
+		this.accessoryManager.setup({
+			page: this.page,
+			scrollView,
+			inputContainer,
+			textView: this.textView,
+		});
+
+		this.isAccessorySetup = true;
+		this.scrollToBottom();
+	}
+
+	private appendMessage(message: string) {
+		const currentMessages = (this.get('messages') as string[]) || [];
+		this.set('messages', [...currentMessages, message]);
+		this.scrollToBottom();
+	}
+
+	private scrollToBottom() {
+		setTimeout(() => {
+			this.accessoryManager?.updateAccessoryHeight();
+			this.accessoryManager?.relayoutScrollViewContent();
+			const scrollView = this.page.getViewById<ScrollView>('messagesScrollView');
+			scrollView?.scrollToVerticalOffset(scrollView.scrollableHeight, true);
+		}, 100);
+	}
+}

--- a/apps/demo/src/plugin-demos/input-accessory.xml
+++ b/apps/demo/src/plugin-demos/input-accessory.xml
@@ -1,0 +1,30 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo" class="page">
+  <Page.actionBar>
+    <ActionBar title="input-accessory" icon="" class="action-bar">
+    </ActionBar>
+  </Page.actionBar>
+  <GridLayout rows="auto,*, auto">
+    <StackLayout class="p-4" tap="{{ dismissKeyboard }}">
+      <Label text="Keyboard attached input bar demo" class="h2 mb-2" textWrap="true" />
+      <Label text="Try dragging the list while the keyboard is visible for interactive dismiss." class="mb-4 leading-[3]" textWrap="true" />
+    </StackLayout>
+    <GridLayout row="1" class="mx-4" iosOverflowSafeArea="false">
+      <ScrollView id="messagesScrollView">
+        <StackLayout tap="{{ dismissKeyboard }}" class="p-2 mb-14 bg-gray-200 rounded-b-lg">
+
+          <Repeater items="{{ messages }}">
+            <Repeater.itemTemplate>
+              <Label text="{{ $value }}" class="p-2 mb-2 text-sm leading-[3]" textWrap="true" />
+            </Repeater.itemTemplate>
+          </Repeater>
+        </StackLayout>
+      </ScrollView>
+
+    </GridLayout>
+
+    <GridLayout id="inputContainer" row="2" columns="*, auto" class="px-5 pb-2">
+      <TextView id="messageInput" col="0" text="{{ inputText }}" hint="Type a message..." textChange="{{ onMessageTextChange }}" loaded="{{ onMessageInputLoaded }}" returnKeyType="send" class="pl-4 py-4 rounded-full bg-white/30 leading-[2]" />
+      <Button col="1" text="Send" tap="{{ sendMessage }}" class="text-blue-500 ml-2" />
+    </GridLayout>
+  </GridLayout>
+</Page>

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -50,7 +50,8 @@
 			"@nativescript/google-mobile-ads": ["../../packages/google-mobile-ads/index.d.ts"],
 			"@nativescript/google-mobile-ads/angular": ["../../packages/google-mobile-ads/angular/index.ts"],
 			"@nativescript/google-maps-utils": ["../../packages/google-maps-utils/index.d.ts"],
-			"@nativescript/keyboard-toolbar": ["../../packages/keyboard-toolbar/index.d.ts"]
+			"@nativescript/keyboard-toolbar": ["../../packages/keyboard-toolbar/index.d.ts"],
+			"@nativescript/input-accessory": ["../../packages/input-accessory/index.d.ts"]
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@nativescript/core": "~8.9.0",
 		"@nativescript/plugin-tools": "5.5.3",
 		"@nativescript/tailwind": "^2.1.0",
-		"@nativescript/types": "~8.9.0",
+		"@nativescript/types": "~9.0.0",
 		"@nativescript/webpack": "5.0.24",
 		"@ngtools/webpack": "^19.0.0",
 		"@types/geojson": "^7946.0.7",

--- a/packages/input-accessory/.eslintrc.json
+++ b/packages/input-accessory/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*", "node_modules/**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/packages/input-accessory/README.md
+++ b/packages/input-accessory/README.md
@@ -1,0 +1,310 @@
+# @nativescript/input-accessory
+
+Keyboard input accessory — docked input bar, interactive dismiss, and auto-scroll on both iOS and Android. Commonly used with chat interfaces, search focused views, or anywhere you want a keyboard-attached input experience.
+
+## Features
+
+- **iOS**: Moves your input bar into a [inputAccessoryView](https://developer.apple.com/documentation/uikit/uiresponder/inputaccessoryview) docked to the keyboard with system blur effect, interactive dismiss via scroll gesture, and smooth keyboard transitions (like iMessage)
+- **Android**: Uses [WindowInsetsAnimationCompat](https://developer.android.com/reference/androidx/core/view/WindowInsetsAnimationCompat) for smooth keyboard transitions with `translationY` animation, interactive swipe-to-dismiss, and scroll padding management (API 30+)
+- **Auto-growing input**: Automatically resizes the accessory as the [TextView](https://docs.nativescript.org/ui/text-view) content grows (up to a configurable max height)
+- **Auto-scroll**: Scrolls to bottom when the keyboard appears; maintains scroll position when it hides
+- **Any layout**: Use any NativeScript view markup for your input bar — the plugin handles the keyboard docking
+
+## Installation
+
+```bash
+npm install @nativescript/input-accessory
+```
+
+## Usage
+
+- one `ScrollView` for content
+- one input container at the bottom
+- one `TextView`
+- call `setup(...)` after views are loaded
+- call `updateAccessoryHeight()` on `textChange`
+- call `cleanup()` on teardown
+
+### Core (XML + TypeScript)
+
+```xml
+<Page navigatingTo="navigatingTo" class="page" xmlns="http://schemas.nativescript.org/tns.xsd">
+  <GridLayout rows="*, auto">
+    <ScrollView id="scrollView" row="0">
+      <StackLayout tap="{{ dismissKeyboard }}">
+        <Label text="Messages..." />
+      </StackLayout>
+    </ScrollView>
+
+    <GridLayout id="inputContainer" row="1" columns="*, auto" class="p-8">
+      <TextView
+        id="messageInput"
+        col="0"
+        hint="Type..."
+        text="{{ inputText }}"
+        loaded="{{ onTextViewLoaded }}"
+        textChange="{{ onTextChange }}"
+      />
+      <Button col="1" text="Send" tap="{{ send }}" />
+    </GridLayout>
+  </GridLayout>
+</Page>
+```
+
+```ts
+import { EventData, Observable, Page, ScrollView, TextView, View } from '@nativescript/core';
+import { InputAccessoryManager } from '@nativescript/input-accessory';
+
+export function navigatingTo(args: EventData) {
+  const page = args.object as Page;
+  page.bindingContext = new DemoModel(page);
+}
+
+class DemoModel extends Observable {
+  private manager: InputAccessoryManager | null = null;
+  private textView: TextView | null = null;
+
+  constructor(private page: Page) {
+    super();
+    this.set('inputText', '');
+    this.page.on(Page.navigatingFromEvent, () => this.manager?.cleanup());
+  }
+
+  onTextViewLoaded(args: EventData) {
+    this.textView = args.object as TextView;
+    const scrollView = this.page.getViewById<ScrollView>('scrollView');
+    const inputContainer = this.page.getViewById<View>('inputContainer');
+    if (!scrollView || !inputContainer || !this.textView || this.manager) return;
+
+    this.manager = new InputAccessoryManager();
+    this.manager.setup({ page: this.page, scrollView, inputContainer, textView: this.textView });
+  }
+
+  onTextChange() {
+    this.manager?.updateAccessoryHeight();
+  }
+
+  dismissKeyboard() {
+    this.manager?.dismissKeyboard();
+  }
+
+  send() {
+    this.set('inputText', '');
+    this.manager?.updateAccessoryHeight();
+  }
+}
+```
+
+### Angular
+
+```html
+<GridLayout rows="*, auto">
+  <ScrollView #scrollView row="0"><StackLayout (tap)="dismissKeyboard()"><Label text="Messages..." /></StackLayout></ScrollView>
+  <GridLayout #inputContainer row="1" columns="*, auto">
+    <TextView #messageInput col="0" hint="Type..." (loaded)="onTextViewLoaded($event)" (textChange)="onTextChange()"></TextView>
+    <Button col="1" text="Send"></Button>
+  </GridLayout>
+</GridLayout>
+```
+
+```ts
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild, inject } from '@angular/core';
+import { EventData, Page, ScrollView, TextView, View } from '@nativescript/core';
+import { InputAccessoryManager } from '@nativescript/input-accessory';
+
+@Component({ selector: 'chat', templateUrl: './chat.component.html' })
+export class ChatComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('scrollView', { read: ElementRef }) scrollView!: ElementRef<ScrollView>;
+  @ViewChild('inputContainer', { read: ElementRef }) inputContainer!: ElementRef<View>;
+  private page = inject(Page);
+  private manager: InputAccessoryManager | null = null;
+  private textView: TextView | null = null;
+
+  ngAfterViewInit() {
+    setTimeout(() => this.setup(), 0);
+  }
+
+  onTextViewLoaded(args: EventData) {
+    this.textView = args.object as TextView;
+    this.setup();
+  }
+
+  onTextChange() {
+    this.manager?.updateAccessoryHeight();
+  }
+
+  dismissKeyboard() {
+    this.manager?.dismissKeyboard();
+  }
+
+  ngOnDestroy() {
+    this.manager?.cleanup();
+  }
+
+  private setup() {
+    if (this.manager || !this.textView || !this.scrollView?.nativeElement || !this.inputContainer?.nativeElement) return;
+    this.manager = new InputAccessoryManager();
+    this.manager.setup({
+      page: this.page,
+      scrollView: this.scrollView.nativeElement,
+      inputContainer: this.inputContainer.nativeElement,
+      textView: this.textView,
+    });
+  }
+}
+```
+
+### Solid
+
+```tsx
+import { onCleanup, onMount } from 'solid-js';
+import { Page, ScrollView, TextView, View } from '@nativescript/core';
+import { InputAccessoryManager } from '@nativescript/input-accessory';
+
+export function Home() {
+  let pageRef: Page;
+  let scrollRef: ScrollView;
+  let inputRef: View;
+  let textRef: TextView;
+  const manager = new InputAccessoryManager();
+
+  onMount(() => {
+    manager.setup({ page: pageRef, scrollView: scrollRef, inputContainer: inputRef, textView: textRef });
+  });
+
+  onCleanup(() => manager.cleanup());
+
+  return (
+    <page ref={pageRef!}>
+      <gridLayout rows="*, auto">
+        <scrollView ref={scrollRef!} row={0}><stackLayout><label text="Messages..." /></stackLayout></scrollView>
+        <gridLayout ref={inputRef!} row={1} columns="*, auto">
+          <textView ref={textRef!} col={0} hint="Type..." onTextChange={() => manager.updateAccessoryHeight()} />
+          <button col={1} text="Send" />
+        </gridLayout>
+      </gridLayout>
+    </page>
+  );
+}
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import type { Page, ScrollView, TextView, View } from '@nativescript/core';
+  import { InputAccessoryManager } from '@nativescript/input-accessory';
+
+  let pageRef: Page;
+  let scrollRef: ScrollView;
+  let inputRef: View;
+  let textRef: TextView;
+  const manager = new InputAccessoryManager();
+
+  onMount(() => {
+    manager.setup({ page: pageRef, scrollView: scrollRef, inputContainer: inputRef, textView: textRef });
+  });
+
+  onDestroy(() => manager.cleanup());
+</script>
+
+<Page bind:this={pageRef}>
+  <GridLayout rows="*, auto">
+    <ScrollView bind:this={scrollRef} row="0"><StackLayout><Label text="Messages..." /></StackLayout></ScrollView>
+    <GridLayout bind:this={inputRef} row="1" columns="*, auto">
+      <TextView bind:this={textRef} col="0" hint="Type..." on:textChange={() => manager.updateAccessoryHeight()} />
+      <Button col="1" text="Send" />
+    </GridLayout>
+  </GridLayout>
+</Page>
+```
+
+### Vue
+
+```vue
+<template>
+  <Page @loaded="onPageLoaded" @unloaded="onPageUnloaded">
+    <GridLayout rows="*, auto">
+      <ScrollView ref="scrollView" row="0"><StackLayout @tap="dismissKeyboard"><Label text="Messages..." /></StackLayout></ScrollView>
+      <GridLayout ref="inputContainer" row="1" columns="*, auto">
+        <TextView ref="messageInput" col="0" hint="Type..." @textChange="onTextChange" />
+        <Button col="1" text="Send" />
+      </GridLayout>
+    </GridLayout>
+  </Page>
+</template>
+
+<script lang="ts">
+import { InputAccessoryManager } from '@nativescript/input-accessory';
+
+export default {
+  data() {
+    return {
+      manager: new InputAccessoryManager(),
+    };
+  },
+  methods: {
+    onPageLoaded(args) {
+      this.manager.setup({
+        page: args.object,
+        scrollView: this.$refs.scrollView.nativeView,
+        inputContainer: this.$refs.inputContainer.nativeView,
+        textView: this.$refs.messageInput.nativeView,
+      });
+    },
+    onTextChange() {
+      this.manager.updateAccessoryHeight();
+    },
+    dismissKeyboard() {
+      this.manager.dismissKeyboard();
+    },
+    onPageUnloaded() {
+      this.manager.cleanup();
+    },
+  },
+};
+</script>
+```
+
+## API
+
+### `InputAccessoryConfig`
+
+| Property | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `page` | `Page` | Yes | — | NativeScript Page instance (iOS: viewController access, Android: Activity access) |
+| `scrollView` | `ScrollView` | Yes | — | The ScrollView containing your messages |
+| `inputContainer` | `View` | Yes | — | The View (any layout) that serves as the input bar |
+| `textView` | `TextView` | Yes | — | The TextView for text input (used for auto-height) |
+| `baseHeight` | `number` | No | `48` | Minimum height of the input bar (DIPs) |
+| `maxHeight` | `number` | No | `200` | Maximum height the input bar can grow to (DIPs) |
+| `containerPadding` | `number` | No | `16` | Padding added to text height when calculating container height (DIPs) |
+
+### `InputAccessoryManager`
+
+| Method | Description |
+|---|---|
+| `setup(config)` | Initialize keyboard accessory behavior. Call after all views are loaded. |
+| `updateAccessoryHeight()` | Recalculate height based on current text content. Call on every text change. |
+| `dismissKeyboard()` | Dismiss the keyboard programmatically. |
+| `relayoutScrollViewContent()` | Remeasure ScrollView content after external changes (e.g., new messages added). |
+| `cleanup()` | Remove all listeners and restore original state. Call in `ngOnDestroy`. |
+
+## How it works
+
+### iOS
+
+The plugin creates an invisible `KeyboardTrackingView` that acts as a first responder with a `inputAccessoryView`. Your input bar view is moved into this accessory container, which docks to the keyboard with the system blur effect (`.keyboard` style [UIInputView](https://developer.apple.com/documentation/uikit/uiinputview)). On iOS 26+, [UIScrollEdgeElementContainerInteraction](https://developer.apple.com/documentation/uikit/uiscrolledgeelementcontainerinteraction) provides glass-morphism blending between the ScrollView and the accessory.
+
+Interactive dismiss is handled via a `CADisplayLink` that tracks the accessory position during scroll gestures, updating the ScrollView's `contentInset` every frame.
+
+### Android
+
+The plugin uses a Kotlin helper that hooks into `WindowInsetsAnimationCompat` for per-frame keyboard tracking. It uses a "deferred transition" pattern — NativeScript handles the actual layout changes, and the helper smooths the transition with `translationY` animation. Interactive swipe-to-dismiss is implemented via `controlWindowInsetsAnimation()` which gives direct control over the keyboard position, tracking the user's finger.
+
+Requires API 30+. On older APIs, the plugin is a no-op and default keyboard behavior is used.
+
+## License
+
+Apache-2.0

--- a/packages/input-accessory/common.ts
+++ b/packages/input-accessory/common.ts
@@ -1,0 +1,126 @@
+import { View, TextView, Utils, ScrollView, Page } from '@nativescript/core';
+
+/**
+ * Configuration for setting up the input accessory behavior.
+ */
+export interface InputAccessoryConfig {
+	/**
+	 * The NativeScript Page instance.
+	 * On iOS, used to access the UIViewController for the KeyboardTrackingView.
+	 * On Android, used to access the Activity.
+	 */
+	page: Page;
+
+	/**
+	 * The NativeScript ScrollView that contains the chat messages.
+	 * The plugin manages its content insets (iOS) / padding (Android)
+	 * and handles auto-scroll behavior.
+	 */
+	scrollView: ScrollView;
+
+	/**
+	 * The NativeScript View (any layout) that serves as the input bar.
+	 * On iOS, this view is moved into the inputAccessoryView.
+	 * On Android, translationY animation keeps it above the keyboard.
+	 */
+	inputContainer: View;
+
+	/**
+	 * The NativeScript TextView used for text input.
+	 * Used for auto-height calculation as text grows/shrinks.
+	 * On iOS, the plugin configures scrollEnabled=false and textContainerInset.
+	 */
+	textView: TextView;
+
+	/**
+	 * Base height of the input container in DIPs. Default: 48.
+	 */
+	baseHeight?: number;
+
+	/**
+	 * Maximum height the input container can grow to in DIPs. Default: 200.
+	 */
+	maxHeight?: number;
+
+	/**
+	 * Padding added to the text height when calculating container height. Default: 16.
+	 */
+	containerPadding?: number;
+}
+
+/**
+ * Shared base class for InputAccessoryManager.
+ * Contains platform-agnostic logic for ScrollView content relayout
+ * and common configuration storage.
+ */
+export class InputAccessoryManagerBase {
+	protected nsScrollViewContainer: ScrollView | null = null;
+	protected nsInputContainer: View | null = null;
+	protected textView: TextView | null = null;
+	protected baseHeight: number = 48;
+	protected maxHeight: number = 200;
+	protected containerPadding: number = 16;
+	protected isRelayoutingScrollView: boolean = false;
+
+	/**
+	 * Store common config properties. Platform subclasses call this from setup().
+	 */
+	protected applyConfig(config: InputAccessoryConfig): void {
+		this.nsScrollViewContainer = config.scrollView;
+		this.nsInputContainer = config.inputContainer;
+		this.textView = config.textView;
+		if (config.baseHeight != null) this.baseHeight = config.baseHeight;
+		if (config.maxHeight != null) this.maxHeight = config.maxHeight;
+		if (config.containerPadding != null) this.containerPadding = config.containerPadding;
+	}
+
+	/**
+	 * Relayout ScrollView content after native frame/padding changes.
+	 * Remeasures the NativeScript content child and updates scroll dimensions.
+	 */
+	public relayoutScrollViewContent(): void {
+		if (this.isRelayoutingScrollView) return;
+		if (!this.nsScrollViewContainer) return;
+
+		this.isRelayoutingScrollView = true;
+		try {
+			const stackLayout = this.nsScrollViewContainer.content;
+			if (!stackLayout) return;
+
+			const width = this.getScrollViewWidth();
+			if (width <= 0) return;
+
+			const widthSpec = Utils.layout.makeMeasureSpec(width, Utils.layout.EXACTLY);
+			const heightSpec = Utils.layout.makeMeasureSpec(0, Utils.layout.UNSPECIFIED);
+
+			stackLayout.measure(widthSpec, heightSpec);
+			const measuredHeight = stackLayout.getMeasuredHeight();
+			stackLayout.layout(0, 0, width, measuredHeight);
+
+			this.updateScrollContentSize(width, measuredHeight);
+		} finally {
+			this.isRelayoutingScrollView = false;
+		}
+	}
+
+	/**
+	 * Override per platform to return the native scroll view width in device pixels.
+	 */
+	protected getScrollViewWidth(): number {
+		return 0;
+	}
+
+	/**
+	 * Override on iOS to set UIScrollView.contentSize. No-op on Android.
+	 */
+	protected updateScrollContentSize(_width: number, _measuredHeight: number): void {}
+
+	/**
+	 * Common cleanup of TypeScript-side references.
+	 */
+	protected cleanupBase(): void {
+		this.nsScrollViewContainer = null;
+		this.nsInputContainer = null;
+		this.textView = null;
+	}
+}

--- a/packages/input-accessory/index.android.ts
+++ b/packages/input-accessory/index.android.ts
@@ -1,0 +1,120 @@
+import { Utils, Application } from '@nativescript/core';
+import { InputAccessoryManagerBase, InputAccessoryConfig } from './common';
+
+export class InputAccessoryManager extends InputAccessoryManagerBase {
+	private helper: org.nativescript.inputaccessory.KeyboardAccessoryHelper | null = null;
+
+	setup(config: InputAccessoryConfig): void {
+		this.applyConfig(config);
+
+		const nativeScrollView = config.scrollView.android as android.widget.ScrollView;
+		const nativeInputContainer = config.inputContainer.android as android.view.View;
+
+		if (!nativeScrollView || !nativeInputContainer) {
+			console.error('[InputAccessory] Native views not ready');
+			return;
+		}
+
+		// API 30+ required for reliable WindowInsetsAnimationCompat.
+		// On older APIs, skip — NativeScript's default keyboard behavior works fine.
+		if (android.os.Build.VERSION.SDK_INT < 30) {
+			console.log('[InputAccessory] API < 30, using default keyboard behavior');
+			return;
+		}
+
+		const activity = Application.android.foregroundActivity || Application.android.startActivity;
+		if (!activity) {
+			console.error('[InputAccessory] No activity available');
+			return;
+		}
+
+		// Get initial height in pixels
+		const frameHeight = nativeInputContainer.getHeight();
+		const maxInitialPx = Utils.layout.toDevicePixels(50);
+		const inputHeightPx = frameHeight > 0 && frameHeight <= maxInitialPx ? frameHeight : Utils.layout.toDevicePixels(this.baseHeight);
+		this.baseHeight = Utils.layout.toDeviceIndependentPixels(inputHeightPx);
+
+		// Create native helper
+		this.helper = new org.nativescript.inputaccessory.KeyboardAccessoryHelper(activity, nativeInputContainer, nativeScrollView, inputHeightPx);
+
+		// Bridge callback: Kotlin -> TypeScript
+		const self = this;
+		const callbackImpl = new org.nativescript.inputaccessory.KeyboardAccessoryHelper.KeyboardStateCallback({
+			onKeyboardHeightChanged(_heightPx: number, _isAnimating: boolean): void {
+				// Per-frame during animation — handled by Kotlin (translationY + padding)
+			},
+			onKeyboardFullyShown(_heightPx: number): void {
+				self.handleKeyboardShown();
+			},
+			onKeyboardFullyHidden(): void {
+				self.handleKeyboardHidden();
+			},
+			onRelayoutScrollContent(): void {
+				self.relayoutScrollViewContent();
+			},
+		});
+
+		this.helper.setup(callbackImpl);
+	}
+
+	updateAccessoryHeight(): void {
+		if (!this.helper || !this.textView) return;
+
+		const nativeEditText = this.textView.android as android.widget.EditText;
+		if (!nativeEditText) return;
+
+		// Measure natural text height using Android's measure system
+		const currentWidth = nativeEditText.getWidth();
+		if (currentWidth <= 0) return;
+
+		const widthSpec = android.view.View.MeasureSpec.makeMeasureSpec(currentWidth, android.view.View.MeasureSpec.EXACTLY);
+		const heightSpec = android.view.View.MeasureSpec.makeMeasureSpec(0, android.view.View.MeasureSpec.UNSPECIFIED);
+		nativeEditText.measure(widthSpec, heightSpec);
+		const textHeightDip = Utils.layout.toDeviceIndependentPixels(nativeEditText.getMeasuredHeight());
+
+		let newHeight = textHeightDip + this.containerPadding;
+		newHeight = Math.max(this.baseHeight, Math.min(newHeight, this.maxHeight));
+
+		// Update native helper (pass pixels)
+		this.helper.updateAccessoryHeight(Utils.layout.toDevicePixels(newHeight));
+	}
+
+	dismissKeyboard(): void {
+		if (this.helper) {
+			this.helper.dismissKeyboard();
+		}
+	}
+
+	cleanup(): void {
+		if (this.helper) {
+			this.helper.cleanup();
+			this.helper = null;
+		}
+		this.cleanupBase();
+	}
+
+	// MARK: - Android-specific scroll behavior
+
+	private handleKeyboardShown(): void {
+		if (!this.helper) return;
+		// Small delay to let padding settle before scrolling
+		setTimeout(() => {
+			this.helper?.scrollToBottom();
+		}, 50);
+	}
+
+	private handleKeyboardHidden(): void {
+		if (!this.helper) return;
+		this.helper.clampScrollPosition();
+		this.relayoutScrollViewContent();
+	}
+
+	// MARK: - Base class overrides
+
+	protected getScrollViewWidth(): number {
+		if (!this.nsScrollViewContainer) return 0;
+		const nativeScrollView = this.nsScrollViewContainer.android as android.widget.ScrollView;
+		if (!nativeScrollView) return 0;
+		return nativeScrollView.getWidth(); // Already in device pixels on Android
+	}
+}

--- a/packages/input-accessory/index.d.ts
+++ b/packages/input-accessory/index.d.ts
@@ -1,0 +1,41 @@
+import { View, TextView, ScrollView, Page } from '@nativescript/core';
+
+export { InputAccessoryConfig } from './common';
+
+/**
+ * Manages keyboard accessory behavior for chat-style interfaces.
+ *
+ * On iOS: Moves the input container into a UIInputAccessoryView docked to the
+ * keyboard with blur effect, interactive dismiss, and auto-scroll.
+ *
+ * On Android: Uses WindowInsetsAnimationCompat for smooth keyboard transitions
+ * with translationY animation and interactive swipe-to-dismiss.
+ */
+export class InputAccessoryManager {
+	/**
+	 * Initialize the keyboard accessory with the given configuration.
+	 * Call after all views are loaded
+	 */
+	setup(config: InputAccessoryConfig): void;
+
+	/**
+	 * Recalculate and update the accessory height based on current text content.
+	 * Call on every text change event.
+	 */
+	updateAccessoryHeight(): void;
+
+	/**
+	 * Dismiss the keyboard programmatically.
+	 */
+	dismissKeyboard(): void;
+
+	/**
+	 * Relayout ScrollView content after external changes (e.g., new messages).
+	 */
+	relayoutScrollViewContent(): void;
+
+	/**
+	 * Clean up all listeners, observers, and native resources.
+	 */
+	cleanup(): void;
+}

--- a/packages/input-accessory/index.ios.ts
+++ b/packages/input-accessory/index.ios.ts
@@ -1,0 +1,149 @@
+import { Utils } from '@nativescript/core';
+import { InputAccessoryManagerBase, InputAccessoryConfig } from './common';
+
+export class InputAccessoryManager extends InputAccessoryManagerBase {
+	private keyboardTrackingView: KeyboardTrackingView | null = null;
+	private scrollView: UIScrollView | null = null;
+	private inputContainerView: UIView | null = null;
+
+	setup(config: InputAccessoryConfig): void {
+		this.applyConfig(config);
+
+		const scrollViewNative = config.scrollView.ios as UIScrollView;
+		this.scrollView = scrollViewNative;
+		this.inputContainerView = config.inputContainer.ios as UIView;
+
+		// Determine initial height from the current frame or fall back to baseHeight
+		const frameHeight = this.inputContainerView.frame.size.height;
+		const inputHeight = frameHeight > 0 && frameHeight <= 50 ? frameHeight : this.baseHeight;
+		this.baseHeight = inputHeight;
+
+		// Get UIViewController from NativeScript Page
+		const viewController = config.page.viewController as UIViewController;
+
+		// Create native KeyboardTrackingView (invisible, just for first responder chain)
+		this.keyboardTrackingView = KeyboardTrackingView.alloc().initWithFrame(CGRectMake(0, 0, 0, 0));
+		viewController.view.addSubview(this.keyboardTrackingView);
+
+		// Swift moves the native UIView into the inputAccessoryView
+		this.keyboardTrackingView.setupWithInputContainerScrollViewHeight(this.inputContainerView, scrollViewNative, inputHeight);
+
+		// Collapse the NativeScript View in the parent GridLayout.
+		// This makes the row = 0 height and prevents the parent from calling
+		// _setNativeViewFrame (which would conflict with the accessory positioning).
+		config.inputContainer.isCollapsed = true;
+		if (config.inputContainer.parent) {
+			config.inputContainer.parent.requestLayout();
+		}
+
+		// Set the callback so Swift can trigger ScrollView content relayout
+		this.keyboardTrackingView.setScrollViewRelayoutCallback(() => {
+			this.relayoutScrollViewContent();
+		});
+
+		// Configure UITextView for auto-growing
+		const nativeTextView = config.textView.ios as UITextView;
+		if (nativeTextView) {
+			nativeTextView.scrollEnabled = false;
+			nativeTextView.textContainerInset = new UIEdgeInsets({
+				top: 10,
+				left: 10,
+				bottom: 10,
+				right: 10,
+			});
+		}
+
+		// Run initial layout of children within the accessory dimensions
+		setTimeout(() => this.relayoutAccessory(), 50);
+	}
+
+	updateAccessoryHeight(): void {
+		if (!this.keyboardTrackingView || !this.textView) return;
+
+		const nativeTextView = this.textView.ios as UITextView;
+		if (!nativeTextView) return;
+
+		// sizeThatFits returns the natural text height
+		const currentWidth = nativeTextView.frame.size.width;
+		const fittingSize = nativeTextView.sizeThatFits(CGSizeMake(currentWidth, 10000));
+
+		let newHeight = fittingSize.height + this.containerPadding;
+		newHeight = Math.max(this.baseHeight, Math.min(newHeight, this.maxHeight));
+
+		// Update native accessory container height
+		this.keyboardTrackingView.updateHeight(newHeight);
+
+		// Re-layout NativeScript children within the new dimensions
+		this.relayoutAccessory();
+	}
+
+	/**
+	 * Dismiss the keyboard by transferring first responder to the KeyboardTrackingView.
+	 * This keeps the accessory visible (single transition) instead of dismissSoftInput()
+	 * which briefly removes the accessory and causes a scroll jump.
+	 */
+	dismissKeyboard(): void {
+		if (this.keyboardTrackingView) {
+			this.keyboardTrackingView.setDismissingKeyboard();
+			this.keyboardTrackingView.becomeFirstResponder();
+		}
+	}
+
+	cleanup(): void {
+		if (this.keyboardTrackingView) {
+			this.keyboardTrackingView.cleanup();
+			this.keyboardTrackingView.removeFromSuperview();
+			this.keyboardTrackingView = null;
+		}
+		this.scrollView = null;
+		this.inputContainerView = null;
+		this.cleanupBase();
+	}
+
+	// MARK: - iOS-specific relayout
+
+	/**
+	 * Manually trigger NativeScript's measure + layout cycle on the input container.
+	 * Since isCollapsed=true prevents the parent from doing this, we call
+	 * measure() and layout() directly.
+	 */
+	private relayoutAccessory(): void {
+		if (!this.nsInputContainer || !this.inputContainerView) return;
+
+		const frame = this.inputContainerView.frame;
+		const width = frame.size.width;
+		const height = frame.size.height;
+
+		if (width <= 0 || height <= 0) return;
+
+		const dpWidth = Utils.layout.toDevicePixels(width);
+		const dpHeight = Utils.layout.toDevicePixels(height);
+
+		const widthSpec = Utils.layout.makeMeasureSpec(dpWidth, Utils.layout.EXACTLY);
+		const heightSpec = Utils.layout.makeMeasureSpec(dpHeight, Utils.layout.EXACTLY);
+
+		this.nsInputContainer.measure(widthSpec, heightSpec);
+		this.nsInputContainer.layout(0, 0, dpWidth, dpHeight);
+
+		// Force hint placeholder to re-render after reparenting into the accessory
+		if (this.textView && (!this.textView.text || this.textView.text.length === 0)) {
+			const hint = this.textView.hint;
+			this.textView.hint = '';
+			this.textView.hint = hint;
+		}
+	}
+
+	// MARK: - Base class overrides
+
+	protected getScrollViewWidth(): number {
+		if (!this.scrollView) return 0;
+		return Utils.layout.toDevicePixels(this.scrollView.frame.size.width);
+	}
+
+	protected updateScrollContentSize(width: number, measuredHeight: number): void {
+		if (!this.scrollView) return;
+		const dipWidth = Utils.layout.toDeviceIndependentPixels(width);
+		const contentHeight = Utils.layout.toDeviceIndependentPixels(measuredHeight);
+		this.scrollView.contentSize = CGSizeMake(dipWidth, contentHeight);
+	}
+}

--- a/packages/input-accessory/package.json
+++ b/packages/input-accessory/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "@nativescript/input-accessory",
+	"version": "1.0.0",
+	"description": "iOS/Android keyboard input accessory for NativeScript chat UIs — docked input bar, interactive dismiss, auto-scroll",
+	"main": "index",
+	"types": "index.d.ts",
+	"nativescript": {
+		"platforms": {
+			"ios": "9.0.0",
+			"android": "9.0.0"
+		}
+	},
+	"keywords": [
+		"NativeScript",
+		"keyboard",
+		"input-accessory",
+		"chat",
+		"iOS",
+		"Android",
+		"inputAccessoryView"
+	],
+	"author": {
+		"name": "NativeScript",
+		"email": "oss@nativescript.org"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/NativeScript/plugins.git"
+	},
+	"bugs": {
+		"url": "https://github.com/NativeScript/plugins/issues"
+	},
+	"homepage": "https://github.com/NativeScript/plugins",
+	"readmeFilename": "README.md",
+	"bootstrapper": "@nativescript/plugin-seed",
+	"license": "Apache-2.0"
+}

--- a/packages/input-accessory/platforms/android/include.gradle
+++ b/packages/input-accessory/platforms/android/include.gradle
@@ -1,0 +1,9 @@
+android {
+  defaultConfig {
+    minSdkVersion 24
+  }
+}
+
+dependencies {
+  implementation 'androidx.core:core-ktx:1.12.0'
+}

--- a/packages/input-accessory/platforms/android/java/org/nativescript/inputaccessory/KeyboardAccessoryHelper.kt
+++ b/packages/input-accessory/platforms/android/java/org/nativescript/inputaccessory/KeyboardAccessoryHelper.kt
@@ -1,0 +1,414 @@
+package org.nativescript.inputaccessory
+
+import android.app.Activity
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.LinearInterpolator
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsAnimationControllerCompat
+import androidx.core.view.WindowInsetsAnimationControlListenerCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.graphics.Insets
+import java.lang.ref.WeakReference
+import kotlin.math.abs
+import kotlin.math.max
+
+/**
+ * KeyboardAccessoryHelper
+ *
+ * Works WITH NativeScript's layout system using the "deferred transition" pattern:
+ * - NativeScript handles the actual keyboard layout (resize, reposition)
+ * - We smooth the transition with translationY animation
+ * - We provide interactive swipe-to-dismiss that tracks the finger
+ * - We report keyboard state changes to TypeScript
+ *
+ * Does NOT override softInputMode or setDecorFitsSystemWindows —
+ * NativeScript handles those via androidOverflowEdge and its defaults.
+ */
+class KeyboardAccessoryHelper(
+    activity: Activity,
+    private val inputContainer: View,
+    private val scrollView: View,  // NativeScript's VerticalScrollView
+    private var accessoryHeightPx: Int
+) {
+    /**
+     * Callback interface for TypeScript bridge.
+     * All methods are called on the main thread.
+     */
+    interface KeyboardStateCallback {
+        fun onKeyboardHeightChanged(heightPx: Int, isAnimating: Boolean)
+        fun onKeyboardFullyShown(heightPx: Int)
+        fun onKeyboardFullyHidden()
+        fun onRelayoutScrollContent()
+    }
+
+    private val scrollViewGroup: ViewGroup = scrollView as ViewGroup
+    private val activityRef = WeakReference(activity)
+    private var callback: KeyboardStateCallback? = null
+    private var currentKeyboardHeightPx = 0
+    private var isKeyboardVisible = false
+
+    // Deferred transition: positions captured before/after NativeScript relayout
+    private var inputStartBottom = 0
+    private var scrollStartBottom = 0
+
+    // Interactive dismiss state
+    private var insetsController: WindowInsetsControllerCompat? = null
+    private var animationController: WindowInsetsAnimationControllerCompat? = null
+    private var isInteractiveDismissActive = false
+    private var isControllerReady = false
+    private var touchStartY = 0f
+    // Y position of the last raw touch — updated every ACTION_MOVE for velocity/position
+    private var lastTouchY = 0f
+
+    // ──────────────────────────────────────────────
+    // Public API
+    // ──────────────────────────────────────────────
+
+    fun setup(cb: KeyboardStateCallback) {
+        val activity = activityRef.get() ?: return
+        this.callback = cb
+
+        // DO NOT change softInputMode or setDecorFitsSystemWindows.
+        // NativeScript handles keyboard layout via its defaults + androidOverflowEdge.
+
+        insetsController = WindowCompat.getInsetsController(activity.window, activity.window.decorView)
+
+        // Set up smooth animation and interactive dismiss
+        setupInsetsAnimation(activity)
+        setupInteractiveDismiss()
+
+        // clipToPadding=false allows content to scroll behind the input bar
+        scrollViewGroup.clipToPadding = false
+        applyScrollViewPadding()
+    }
+
+    fun updateAccessoryHeight(newHeightPx: Int) {
+        if (abs(accessoryHeightPx - newHeightPx) < 2) return
+        accessoryHeightPx = newHeightPx
+        applyScrollViewPadding()
+    }
+
+    fun dismissKeyboard() {
+        insetsController?.hide(WindowInsetsCompat.Type.ime())
+    }
+
+    fun showKeyboard() {
+        insetsController?.show(WindowInsetsCompat.Type.ime())
+    }
+
+    fun cleanup() {
+        val activity = activityRef.get()
+        if (activity != null) {
+            ViewCompat.setWindowInsetsAnimationCallback(activity.window.decorView, null)
+        }
+
+        // Reset any lingering translation
+        inputContainer.translationY = 0f
+
+        // Remove touch listener
+        scrollView.setOnTouchListener(null)
+
+        callback = null
+        insetsController = null
+        animationController = null
+        isControllerReady = false
+    }
+
+    // ──────────────────────────────────────────────
+    // Deferred transition — smooth keyboard animation
+    // ──────────────────────────────────────────────
+
+    private fun setupInsetsAnimation(activity: Activity) {
+        val decorView = activity.window.decorView
+
+        ViewCompat.setWindowInsetsAnimationCallback(
+            decorView,
+            object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_CONTINUE_ON_SUBTREE) {
+
+                override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+                    // BEFORE layout change: capture current positions
+                    inputStartBottom = inputContainer.bottom
+                    scrollStartBottom = scrollView.bottom
+                }
+
+                override fun onStart(
+                    animation: WindowInsetsAnimationCompat,
+                    bounds: WindowInsetsAnimationCompat.BoundsCompat
+                ): WindowInsetsAnimationCompat.BoundsCompat {
+                    // AFTER layout change: NativeScript has repositioned views to final state.
+                    // Apply reverse translationY so views APPEAR at their original positions.
+                    // onProgress will animate translationY toward 0 (final position).
+                    val inputDelta = (inputStartBottom - inputContainer.bottom).toFloat()
+                    inputContainer.translationY = inputDelta
+
+                    return bounds
+                }
+
+                override fun onProgress(
+                    insets: WindowInsetsCompat,
+                    runningAnimations: List<WindowInsetsAnimationCompat>
+                ): WindowInsetsCompat {
+                    val imeAnim = runningAnimations.find {
+                        it.typeMask and WindowInsetsCompat.Type.ime() != 0
+                    } ?: return insets
+
+                    // During interactive dismiss, hold at start position until controller is ready.
+                    // This prevents the input bar from jumping before we can track the finger.
+                    val fraction = if (isInteractiveDismissActive && !isControllerReady) {
+                        0f
+                    } else {
+                        imeAnim.interpolatedFraction
+                    }
+
+                    // Interpolate: from start position (full delta) toward end position (0)
+                    val inputDelta = (inputStartBottom - inputContainer.bottom).toFloat()
+                    inputContainer.translationY = inputDelta * (1f - fraction)
+
+                    // Report keyboard height for scroll behavior
+                    val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+                    val navInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+                    val kbHeight = max(0, imeInsets.bottom - navInsets.bottom)
+                    callback?.onKeyboardHeightChanged(kbHeight, true)
+
+                    return insets
+                }
+
+                override fun onEnd(animation: WindowInsetsAnimationCompat) {
+                    // Animation complete — clear translation, views at final NativeScript positions
+                    inputContainer.translationY = 0f
+
+                    val insets = ViewCompat.getRootWindowInsets(decorView) ?: return
+                    val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+                    val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+                    val navInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+                    val keyboardHeight = if (imeVisible) {
+                        max(0, imeInsets.bottom - navInsets.bottom)
+                    } else 0
+
+                    val wasVisible = isKeyboardVisible
+                    currentKeyboardHeightPx = keyboardHeight
+                    isKeyboardVisible = imeVisible
+
+                    callback?.onRelayoutScrollContent()
+
+                    if (imeVisible && !wasVisible) {
+                        callback?.onKeyboardFullyShown(keyboardHeight)
+                    } else if (!imeVisible && wasVisible) {
+                        callback?.onKeyboardFullyHidden()
+                    }
+                }
+            }
+        )
+    }
+
+    // ──────────────────────────────────────────────
+    // ScrollView padding (for scroll-behind effect)
+    // ──────────────────────────────────────────────
+
+    private fun applyScrollViewPadding() {
+        // Bottom padding = accessory height so content can scroll behind the input bar
+        scrollView.setPadding(
+            scrollView.paddingLeft,
+            scrollView.paddingTop,
+            scrollView.paddingRight,
+            accessoryHeightPx
+        )
+    }
+
+    // ──────────────────────────────────────────────
+    // Scroll behavior (matches iOS)
+    // ──────────────────────────────────────────────
+
+    /**
+     * Auto-scroll to bottom when keyboard opens.
+     * Called from TypeScript after onKeyboardFullyShown.
+     */
+    fun scrollToBottom() {
+        val contentHeight = getScrollContentHeight()
+        val visibleHeight = scrollView.height - scrollView.paddingBottom
+        val maxScroll = max(0, contentHeight - visibleHeight)
+        if (contentHeight > visibleHeight) {
+            scrollView.scrollTo(0, maxScroll)
+        }
+    }
+
+    /**
+     * Clamp scroll position to valid range.
+     * Called from TypeScript after onKeyboardFullyHidden.
+     */
+    fun clampScrollPosition() {
+        val contentHeight = getScrollContentHeight()
+        val visibleHeight = scrollView.height - scrollView.paddingBottom
+        val maxScroll = max(0, contentHeight - visibleHeight)
+        val clamped = max(0, Math.min(scrollView.scrollY, maxScroll))
+        if (clamped != scrollView.scrollY) {
+            scrollView.scrollTo(0, clamped)
+        }
+    }
+
+    private fun getScrollContentHeight(): Int {
+        return if (scrollViewGroup.childCount > 0) scrollViewGroup.getChildAt(0).height else 0
+    }
+
+    // ──────────────────────────────────────────────
+    // Interactive swipe-to-dismiss
+    //
+    // Flow:
+    // 1. ACTION_DOWN on scroll view → record start Y
+    // 2. ACTION_MOVE with keyboard visible + downward drag > threshold at scroll bottom
+    //    → request animation control via controlWindowInsetsAnimation()
+    // 3. onReady → anchor keyboard at shown position (prevents snap), mark ready
+    // 4. ACTION_MOVE with controller ready → setInsetsAndAlpha to track finger
+    // 5. ACTION_UP → finish(false) to dismiss or finish(true) to snap back
+    //
+    // The deferred transition callback (onPrepare/onStart/onProgress/onEnd) handles
+    // the input bar positioning automatically during the controlled animation.
+    // ──────────────────────────────────────────────
+
+    private fun setupInteractiveDismiss() {
+        scrollView.setOnTouchListener(object : View.OnTouchListener {
+            override fun onTouch(v: View, event: MotionEvent): Boolean {
+                when (event.actionMasked) {
+                    MotionEvent.ACTION_DOWN -> {
+                        touchStartY = event.rawY
+                        lastTouchY = event.rawY
+                    }
+                    MotionEvent.ACTION_MOVE -> {
+                        lastTouchY = event.rawY
+
+                        if (!isInteractiveDismissActive && isKeyboardVisible) {
+                            val deltaY = event.rawY - touchStartY
+                            // Only start interactive dismiss when:
+                            // 1. User is swiping down (deltaY > 0)
+                            // 2. Significant enough movement (> 20px)
+                            // 3. ScrollView is at or near bottom
+                            if (deltaY > 20 && isScrolledNearBottom()) {
+                                startInteractiveDismiss()
+                            }
+                        }
+
+                        if (isInteractiveDismissActive) {
+                            if (isControllerReady) {
+                                // Controller ready — track the finger
+                                val deltaY = event.rawY - touchStartY
+                                updateInteractiveDismiss(deltaY)
+                            }
+                            // Consume touch whether controller is ready or not,
+                            // so ScrollView doesn't interfere with the gesture
+                            return true
+                        }
+                    }
+                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                        if (isInteractiveDismissActive) {
+                            val deltaY = event.rawY - touchStartY
+                            finishInteractiveDismiss(deltaY)
+                            return true
+                        }
+                    }
+                }
+                return false // Let ScrollView handle its own touches
+            }
+        })
+    }
+
+    private fun isScrolledNearBottom(): Boolean {
+        val contentHeight = getScrollContentHeight()
+        val visibleHeight = scrollView.height - scrollView.paddingBottom
+        val maxScroll = max(0, contentHeight - visibleHeight)
+        return (maxScroll < 10) || (maxScroll - scrollView.scrollY < 50)
+    }
+
+    private fun startInteractiveDismiss() {
+        val activity = activityRef.get() ?: return
+        isInteractiveDismissActive = true
+        isControllerReady = false
+
+        val controller = WindowCompat.getInsetsController(activity.window, activity.window.decorView)
+        controller.controlWindowInsetsAnimation(
+            WindowInsetsCompat.Type.ime(),
+            -1, // no duration limit — we drive the animation
+            LinearInterpolator(),
+            null,
+            object : WindowInsetsAnimationControlListenerCompat {
+                override fun onReady(
+                    ctrl: WindowInsetsAnimationControllerCompat,
+                    types: Int
+                ) {
+                    animationController = ctrl
+                    isControllerReady = true
+
+                    // Anchor keyboard at shown position immediately.
+                    // This prevents the keyboard from snapping to hidden
+                    // during the gap between requesting control and getting it.
+                    ctrl.setInsetsAndAlpha(ctrl.shownStateInsets, 1f, 0f)
+                }
+
+                override fun onFinished(ctrl: WindowInsetsAnimationControllerCompat) {
+                    animationController = null
+                    isInteractiveDismissActive = false
+                    isControllerReady = false
+                }
+
+                override fun onCancelled(ctrl: WindowInsetsAnimationControllerCompat?) {
+                    animationController = null
+                    isInteractiveDismissActive = false
+                    isControllerReady = false
+                }
+            }
+        )
+    }
+
+    private fun updateInteractiveDismiss(deltaY: Float) {
+        val ctrl = animationController ?: return
+
+        val shownInsets = ctrl.shownStateInsets
+        val hiddenInsets = ctrl.hiddenStateInsets
+        val totalRange = shownInsets.bottom - hiddenInsets.bottom
+
+        if (totalRange <= 0) return
+
+        // Map finger delta to keyboard position.
+        // deltaY > 0 = finger moved down → keyboard should move down (fraction increases)
+        val fraction = (deltaY / totalRange).coerceIn(0f, 1f)
+        val currentBottom = (shownInsets.bottom - (totalRange * fraction)).toInt()
+            .coerceIn(hiddenInsets.bottom, shownInsets.bottom)
+
+        ctrl.setInsetsAndAlpha(
+            Insets.of(0, 0, 0, currentBottom),
+            1f,
+            fraction
+        )
+    }
+
+    private fun finishInteractiveDismiss(deltaY: Float) {
+        val ctrl = animationController ?: run {
+            isInteractiveDismissActive = false
+            isControllerReady = false
+            return
+        }
+
+        val shownInsets = ctrl.shownStateInsets
+        val hiddenInsets = ctrl.hiddenStateInsets
+        val totalRange = shownInsets.bottom - hiddenInsets.bottom
+
+        if (totalRange <= 0) {
+            ctrl.finish(true) // show keyboard
+            return
+        }
+
+        val fraction = (deltaY / totalRange).coerceIn(0f, 1f)
+
+        // If user dragged more than 30% of keyboard height, dismiss; otherwise snap back
+        if (fraction > 0.3f) {
+            ctrl.finish(false) // hide keyboard
+        } else {
+            ctrl.finish(true) // snap back (show keyboard)
+        }
+    }
+}

--- a/packages/input-accessory/platforms/ios/src/KeyboardTrackingView.swift
+++ b/packages/input-accessory/platforms/ios/src/KeyboardTrackingView.swift
@@ -1,0 +1,630 @@
+import UIKit
+
+/**
+ * KeyboardTrackingView - A custom UIView that provides interactive keyboard tracking
+ * by using itself as a first responder with an inputAccessoryView.
+ * 
+ * This enables the proper iOS behavior where the input bar is docked to the keyboard
+ * and moves with it during interactive dismissal (like iMessage).
+ */
+@objcMembers
+public class KeyboardTrackingView: UIView {
+    
+    // The view that will be docked to the keyboard
+    private var _keyboardAccessoryView: InputAccessoryContainerView?
+    
+    // Height for the accessory container
+    private var accessoryHeight: CGFloat = 48
+    
+    // The actual content view (our input container)
+    private var contentView: UIView?
+    
+    // Reference to the scroll view for inset adjustments
+    private weak var trackedScrollView: UIScrollView?
+
+    // Maximum height for the input area (prevents infinite growth)
+    private let maxAccessoryHeight: CGFloat = 200
+
+    // Safe area bottom inset for home indicator
+    private var safeAreaBottomInset: CGFloat = 0
+
+    // Track previous keyboard position to detect show/hide direction
+    private var previousKeyboardY: CGFloat = 0
+
+    // Flag to suppress animation during programmatic keyboard dismiss (tap close).
+    private var isDismissingKeyboard: Bool = false
+
+    // Callback for triggering ScrollView content relayout from TypeScript
+    private var scrollViewRelayoutCallback: (() -> Void)?
+
+    // Interactive keyboard dismiss tracking via CADisplayLink
+    private var displayLink: CADisplayLink?
+    private var displayLinkProxy: DisplayLinkProxy?
+    private var isInteractiveDismissActive: Bool = false
+    
+    
+    // MARK: - First Responder Support
+    
+    public override var canBecomeFirstResponder: Bool {
+        return true
+    }
+    
+    public override var inputAccessoryView: UIView? {
+        return _keyboardAccessoryView
+    }
+    
+    // MARK: - Setup
+    
+    /**
+     * Setup the keyboard tracking with the input container view
+     * @param inputContainer The view that should dock to the keyboard
+     * @param scrollView The scroll view to configure for interactive dismiss
+     * @param height The height of the input container
+     */
+    public func setup(inputContainer: UIView, scrollView: UIScrollView, height: CGFloat) {
+        self.accessoryHeight = height
+        self.trackedScrollView = scrollView
+        self.contentView = inputContainer
+
+        // Initialize keyboard tracking (keyboard starts hidden at bottom of screen)
+        self.previousKeyboardY = UIScreen.main.bounds.height
+
+        // Get safe area bottom inset for home indicator padding
+        if #available(iOS 15.0, *) {
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let window = windowScene.windows.first {
+                self.safeAreaBottomInset = max(0, window.safeAreaInsets.bottom - 20)
+            }
+        } else {
+            if let window = UIApplication.shared.windows.first {
+                self.safeAreaBottomInset = max(0, window.safeAreaInsets.bottom - 20)
+            }
+        }
+        
+        // Total height includes content height + safe area for home indicator
+        let totalHeight = height + self.safeAreaBottomInset
+        
+        // Create the accessory view container
+        let screenWidth = UIScreen.main.bounds.width
+        let accessoryContainer = InputAccessoryContainerView(frame: CGRect(x: 0, y: 0, width: screenWidth, height: totalHeight))
+        accessoryContainer.safeAreaBottomInset = self.safeAreaBottomInset
+        accessoryContainer.contentHeight = height
+        
+        // Store original superview and subview index before removal
+        let originalSuperview = inputContainer.superview
+        var originalIndex = 0
+        if let superview = originalSuperview,
+           let idx = superview.subviews.firstIndex(of: inputContainer) {
+            originalIndex = idx
+        }
+
+        // Move input container into accessory view
+        inputContainer.removeFromSuperview()
+
+        // Force clear background so the blur effect shows through
+        inputContainer.backgroundColor = .clear
+
+        // Use frame-based positioning for the NativeScript view.
+        // NativeScript uses frame-based layout internally — setting the frame triggers
+        // layoutSubviews which triggers NativeScript's measure+layout cycle for children.
+        // Auto Layout bypasses this, causing children (like the TextView) not to resize.
+        inputContainer.frame = CGRect(x: 0, y: 0, width: screenWidth, height: height)
+        inputContainer.autoresizingMask = [.flexibleWidth]
+        accessoryContainer.addSubview(inputContainer)
+        accessoryContainer.contentViewRef = inputContainer
+
+        // Create a zero-height, non-interactive placeholder at the original position.
+        // The NativeScript side sets isCollapsed=true on the View, so the GridLayout
+        // gives row 2 zero height and skips layoutChild entirely.
+        // This placeholder keeps the native subview array consistent for the parent.
+        if let superview = originalSuperview {
+            let placeholder = UIView(frame: CGRect(x: 0, y: 0, width: superview.bounds.width, height: 0))
+            placeholder.backgroundColor = .clear
+            placeholder.isUserInteractionEnabled = false
+            placeholder.isHidden = true
+            placeholder.tag = 9999
+            superview.insertSubview(placeholder, at: originalIndex)
+        }
+
+        self._keyboardAccessoryView = accessoryContainer
+        
+        // On iOS 26+, add scroll edge blending so the bottom of the ScrollView
+        // fades into the glass accessory (like Apple Notes / iMessage).
+        if #available(iOS 26.0, *) {
+            let edgeInteraction = UIScrollEdgeElementContainerInteraction()
+            edgeInteraction.scrollView = scrollView
+            edgeInteraction.edge = .bottom
+            accessoryContainer.addInteraction(edgeInteraction)
+        }
+
+        // Set up scroll view for interactive dismiss
+        scrollView.keyboardDismissMode = .interactive
+
+        // Content extends behind the translucent accessory for the blur effect.
+        // contentInset ensures content rests above the accessory while allowing
+        // scroll-through visibility (like Apple Messages).
+        scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: totalHeight, right: 0)
+        scrollView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: totalHeight, right: 0)
+
+        // Track pan gesture for interactive keyboard dismiss tracking
+        scrollView.panGestureRecognizer.addTarget(self, action: #selector(handleScrollViewPan(_:)))
+
+        // Observe keyboard to adjust scroll insets
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillChangeFrame(_:)),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+        
+        // Become first responder to show the accessory view
+        // We need to do this after a slight delay to ensure view hierarchy is ready
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.becomeFirstResponder()
+        }
+    }
+    
+    /**
+     * Set the callback for relayouting ScrollView content
+     * Called from TypeScript during setup
+     */
+    public func setScrollViewRelayoutCallback(_ callback: @escaping () -> Void) {
+        self.scrollViewRelayoutCallback = callback
+    }
+
+    /**
+     * Trigger NativeScript content remeasurement for ScrollView after frame resize
+     */
+    private func relayoutScrollViewContent() {
+        // Call back to TypeScript to remeasure ScrollView content
+        // This ensures contentSize is recalculated after frame changes
+        scrollViewRelayoutCallback?()
+    }
+
+    // MARK: - Interactive Keyboard Dismiss Tracking
+
+    /**
+     * Track scroll view pan gesture to detect interactive keyboard dismiss.
+     * When the user swipes down, iOS moves the keyboard interactively but
+     * keyboardWillChangeFrame only fires at the end. We use a CADisplayLink
+     * to poll the accessory position and resize the ScrollView every frame.
+     */
+    @objc private func handleScrollViewPan(_ gesture: UIPanGestureRecognizer) {
+        switch gesture.state {
+        case .changed:
+            if !isInteractiveDismissActive {
+                // Only start tracking when the keyboard is actually showing.
+                // This avoids activating the display link during normal scrolling.
+                let screenHeight = UIScreen.main.bounds.height
+                let accessoryOnlyThreshold = self.accessoryHeight + self.safeAreaBottomInset + 10
+                if previousKeyboardY < screenHeight - accessoryOnlyThreshold {
+                    startInteractiveTracking()
+                }
+            }
+        case .ended, .cancelled, .failed:
+            // After the snap animation completes (~0.25s), finalize the ScrollView height.
+            // This is a safety net: the notification handler may have already set the correct
+            // frame, but in edge cases (notification missed, display link race) it might not.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.stopInteractiveTracking()
+                self?.finalizeScrollViewHeight()
+            }
+        default:
+            break
+        }
+    }
+
+    private func startInteractiveTracking() {
+        guard displayLink == nil else { return }
+        isInteractiveDismissActive = true
+        let proxy = DisplayLinkProxy(self)
+        displayLinkProxy = proxy
+        displayLink = CADisplayLink(target: proxy, selector: #selector(DisplayLinkProxy.tick))
+        displayLink?.add(to: .main, forMode: .common)
+    }
+
+    private func stopInteractiveTracking() {
+        displayLink?.invalidate()
+        displayLink = nil
+        displayLinkProxy = nil
+        isInteractiveDismissActive = false
+    }
+
+    /**
+     * Safety net: ensure the ScrollView fills from its top to the accessory top.
+     * Called after the snap animation should be complete (~0.5s after gesture ends).
+     * Handles edge cases where the notification handler didn't fire or was overridden.
+     */
+    private func finalizeScrollViewHeight() {
+        guard let accessoryView = _keyboardAccessoryView,
+              let window = accessoryView.window,
+              let scrollView = trackedScrollView else { return }
+
+        let frameInWindow = accessoryView.convert(accessoryView.bounds, to: window)
+        let accessoryTop = frameInWindow.origin.y
+
+        let screenHeight = UIScreen.main.bounds.height
+        let scrollViewTopInWindow = scrollView.superview?.convert(
+            scrollView.frame.origin, to: nil).y ?? scrollView.frame.origin.y
+
+        let targetFrameHeight = max(100, screenHeight - scrollViewTopInWindow)
+        let keyboardOverlap = max(0, screenHeight - accessoryTop)
+
+        let frameChanged = abs(targetFrameHeight - scrollView.frame.size.height) > 1
+        let insetChanged = abs(keyboardOverlap - scrollView.contentInset.bottom) > 1
+        guard frameChanged || insetChanged else { return }
+
+        if frameChanged {
+            var newFrame = scrollView.frame
+            newFrame.size.height = targetFrameHeight
+            scrollView.frame = newFrame
+        }
+
+        scrollView.contentInset.bottom = keyboardOverlap
+        scrollView.verticalScrollIndicatorInsets.bottom = keyboardOverlap
+
+        self.relayoutScrollViewContent()
+    }
+
+    /**
+     * Called every frame by the CADisplayLink during interactive dismiss.
+     * Reads the inputAccessoryView's position in the window and resizes the
+     * ScrollView so it always fills from its top down to the accessory top.
+     */
+    @objc func trackKeyboardPosition() {
+        guard let accessoryView = _keyboardAccessoryView,
+              let window = accessoryView.window,
+              let scrollView = trackedScrollView else { return }
+
+        let frameInWindow = accessoryView.convert(accessoryView.bounds, to: window)
+        let accessoryTop = frameInWindow.origin.y
+
+        let screenHeight = UIScreen.main.bounds.height
+        let scrollViewTopInWindow = scrollView.superview?.convert(
+            scrollView.frame.origin, to: nil).y ?? scrollView.frame.origin.y
+
+        // Frame always extends to screen bottom
+        let targetFrameHeight = max(100, screenHeight - scrollViewTopInWindow)
+
+        // contentInset tracks the moving keyboard+accessory area
+        let keyboardOverlap = max(0, screenHeight - accessoryTop)
+
+        let frameChanged = abs(targetFrameHeight - scrollView.frame.size.height) > 0.5
+        let insetChanged = abs(keyboardOverlap - scrollView.contentInset.bottom) > 0.5
+        guard frameChanged || insetChanged else { return }
+
+        // Check if user is near bottom before changes (account for contentInset)
+        let contentHeight = scrollView.contentSize.height
+        let currentVisibleHeight = scrollView.bounds.height - scrollView.contentInset.bottom
+        let currentMaxOffset = max(0, contentHeight - currentVisibleHeight)
+        let currentOffset = scrollView.contentOffset.y
+        let isNearBottom = (currentMaxOffset < 10) || (currentMaxOffset - currentOffset < 50)
+
+        // Update frame if needed (no animation — tracks finger position)
+        if frameChanged {
+            var newFrame = scrollView.frame
+            newFrame.size.height = targetFrameHeight
+            scrollView.frame = newFrame
+        }
+
+        // Update insets
+        scrollView.contentInset.bottom = keyboardOverlap
+        scrollView.verticalScrollIndicatorInsets.bottom = keyboardOverlap
+
+        // Keep content at bottom if user was near bottom
+        if isNearBottom {
+            let newVisibleHeight = targetFrameHeight - keyboardOverlap
+            let newMaxOffset = max(0, contentHeight - newVisibleHeight)
+            if contentHeight > newVisibleHeight {
+                scrollView.contentOffset = CGPoint(x: 0, y: newMaxOffset)
+            }
+        }
+    }
+
+    /**
+     * Update the height of the accessory view when content size changes (e.g., TextView grows)
+     */
+    public func updateHeight(_ newHeight: CGFloat) {
+        let clampedHeight = min(max(48, newHeight), maxAccessoryHeight)
+
+        guard let accessoryView = _keyboardAccessoryView,
+              abs(self.accessoryHeight - clampedHeight) > 1 else {
+            return
+        }
+
+        self.accessoryHeight = clampedHeight
+
+        // Total height includes safe area
+        let totalHeight = clampedHeight + self.safeAreaBottomInset
+
+        // Update the container's heights
+        accessoryView.contentHeight = clampedHeight
+
+        // Update via the internal height constraint - the reliable way to resize inputAccessoryViews
+        accessoryView.updateHeightConstraint(totalHeight)
+
+        // Note: contentInset is NOT updated here. reloadInputViews() below triggers
+        // a keyboardWillChangeFrame notification which recalculates the full overlap
+        // (keyboard + accessory) and sets the correct contentInset.bottom.
+
+        // Update the content view's frame - this triggers NativeScript's layoutSubviews
+        // which re-measures and re-lays out children (making the TextView actually resize)
+        if let contentView = self.contentView {
+            contentView.frame = CGRect(x: 0, y: 0, width: accessoryView.bounds.width, height: clampedHeight)
+        }
+
+        // reloadInputViews must be called on the ACTUAL first responder.
+        // When the user is typing, the UITextView (inside our accessory) is first responder,
+        // not this KeyboardTrackingView. Find and reload on whichever view is first responder.
+        if let firstResponder = self.findFirstResponder(in: accessoryView) {
+            firstResponder.reloadInputViews()
+        } else {
+            self.reloadInputViews()
+        }
+    }
+
+    /// Recursively find the first responder within a view hierarchy
+    private func findFirstResponder(in view: UIView) -> UIView? {
+        if view.isFirstResponder {
+            return view
+        }
+        for subview in view.subviews {
+            if let responder = findFirstResponder(in: subview) {
+                return responder
+            }
+        }
+        return nil
+    }
+    
+    /**
+     * Show the keyboard (make text field first responder)
+     */
+    public func showKeyboard(textField: UITextField) {
+        textField.becomeFirstResponder()
+    }
+
+    /**
+     * Signal that the keyboard is being dismissed programmatically (tap close).
+     * Must be called immediately before becomeFirstResponder().
+     */
+    public func setDismissingKeyboard() {
+        isDismissingKeyboard = true
+        // Pre-set to keyboard-hidden position so any subsequent notification
+        // sees "keyboard was already hidden" and won't detect a transition.
+        previousKeyboardY = UIScreen.main.bounds.height
+        // Keep the flag active for the full dismiss transition (~0.5s).
+        // Multiple keyboardWillChangeFrame notifications can fire during the
+        // first-responder transfer; clearing on the first one lets the second
+        // go through the animated path and cause the jump.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.isDismissingKeyboard = false
+        }
+    }
+
+    // MARK: - Keyboard Handling
+    
+    @objc private func keyboardWillChangeFrame(_ notification: Notification) {
+        // During interactive dismiss, the display link is already tracking the
+        // keyboard position every frame. Skip the notification handler to avoid
+        // a race (stopping the display link + trying to animate can leave the
+        // ScrollView compressed until the safety-net fires).
+        // Just update previousKeyboardY so state detection stays correct.
+        if isInteractiveDismissActive {
+            if let userInfo = notification.userInfo,
+               let endFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                previousKeyboardY = endFrame.origin.y
+            }
+            return
+        }
+
+        // Stop any leftover interactive tracking (e.g. from delayed cleanup)
+        stopInteractiveTracking()
+
+        guard let scrollView = trackedScrollView,
+              let userInfo = notification.userInfo,
+              let endFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
+            return
+        }
+
+        let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval ?? 0.25
+        let curveValue = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt ?? 7
+        let curve = UIView.AnimationOptions(rawValue: curveValue << 16)
+
+        let screenHeight = UIScreen.main.bounds.height
+        let scrollViewTopInWindow = scrollView.superview?.convert(scrollView.frame.origin, to: nil).y ?? scrollView.frame.origin.y
+
+        // Frame always extends to the screen bottom so content is behind both
+        // the translucent accessory AND the keyboard (for blur-through visibility).
+        let targetFrameHeight = max(100, screenHeight - scrollViewTopInWindow)
+
+        // contentInset covers the full keyboard+accessory area from the screen bottom.
+        // Clamp to at least the accessory height — the accessory is always visible
+        // (KeyboardTrackingView is always first responder), so the overlap never drops
+        // below it. This prevents a transient inset=0 state during first-responder
+        // transfers (e.g., UITextView → KeyboardTrackingView) that would cause a scroll jump.
+        let accessoryTotalHeight = self.accessoryHeight + self.safeAreaBottomInset
+        let keyboardOverlap = max(accessoryTotalHeight, screenHeight - endFrame.origin.y)
+
+        // Detect keyboard showing/hiding for scroll behavior.
+        // iOS includes the inputAccessoryView in the reported keyboard frame,
+        // so when only the accessory is visible (keyboard hidden), endFrame.origin.y
+        // is screenHeight - accessoryHeight - safeArea (~90pt above bottom).
+        // Use the accessory's total height + buffer as the threshold.
+        let accessoryOnlyThreshold = self.accessoryHeight + self.safeAreaBottomInset + 10
+        let isKeyboardShowing = endFrame.origin.y < screenHeight - accessoryOnlyThreshold
+        let wasKeyboardHidden = previousKeyboardY >= screenHeight - accessoryOnlyThreshold
+        let keyboardJustAppeared = isKeyboardShowing && wasKeyboardHidden
+
+        // Store current position for next comparison
+        previousKeyboardY = endFrame.origin.y
+
+        // Calculate if user is at or near bottom BEFORE any changes.
+        // Account for contentInset: visible content area = bounds - inset.
+        let currentOffset = scrollView.contentOffset.y
+        let currentVisibleHeight = scrollView.bounds.height - scrollView.contentInset.bottom
+        let currentMaxOffset = max(0, scrollView.contentSize.height - currentVisibleHeight)
+        let isNearBottom = (currentMaxOffset < 10) || (currentMaxOffset - currentOffset < 100)
+
+        // Trigger NativeScript content remeasurement — updates contentSize
+        self.relayoutScrollViewContent()
+
+        // Only proceed if frame or inset actually changes
+        let frameChanged = abs(targetFrameHeight - scrollView.frame.size.height) > 1
+        let insetChanged = abs(keyboardOverlap - scrollView.contentInset.bottom) > 1
+        guard frameChanged || insetChanged else {
+            return
+        }
+
+        if isDismissingKeyboard {
+            // Don't clear flag here — the timer in setDismissingKeyboard() handles it.
+            // This ensures ALL notifications during the transition are handled instantly.
+
+            if frameChanged {
+                var newFrame = scrollView.frame
+                newFrame.size.height = targetFrameHeight
+                scrollView.frame = newFrame
+            }
+
+            scrollView.contentInset.bottom = keyboardOverlap
+            scrollView.verticalScrollIndicatorInsets.bottom = keyboardOverlap
+
+            // Clamp scroll position to valid range without animation
+            let contentHeight = scrollView.contentSize.height
+            let visibleHeight = targetFrameHeight - keyboardOverlap
+            let maxOffset = max(0, contentHeight - visibleHeight)
+            let clampedOffset = max(0, min(currentOffset, maxOffset))
+            scrollView.contentOffset = CGPoint(x: 0, y: clampedOffset)
+
+            self.relayoutScrollViewContent()
+            return
+        }
+
+        // Animate frame, inset, and scroll position together.
+        UIView.animate(withDuration: duration, delay: 0, options: curve) {
+            if frameChanged {
+                var newFrame = scrollView.frame
+                newFrame.size.height = targetFrameHeight
+                scrollView.frame = newFrame
+            }
+
+            scrollView.contentInset.bottom = keyboardOverlap
+            scrollView.verticalScrollIndicatorInsets.bottom = keyboardOverlap
+
+            // visibleHeight = frame minus the occluded area (keyboard + accessory).
+            let contentHeight = scrollView.contentSize.height
+            let visibleHeight = targetFrameHeight - keyboardOverlap
+            let maxOffset = max(0, contentHeight - visibleHeight)
+
+            // Apple Messages behavior:
+            if keyboardJustAppeared {
+                // Keyboard just opened - scroll to bottom only if there's content to scroll to
+                if contentHeight > visibleHeight {
+                    scrollView.contentOffset = CGPoint(x: 0, y: maxOffset)
+                }
+            } else if isKeyboardShowing && isNearBottom {
+                // User was at bottom - keep them there as frame changes
+                if contentHeight > visibleHeight {
+                    scrollView.contentOffset = CGPoint(x: 0, y: maxOffset)
+                }
+            } else if !isKeyboardShowing && currentOffset > 0 {
+                // Keyboard is hiding - adjust offset to maintain relative position
+                let newOffset = max(0, min(currentOffset, maxOffset))
+                scrollView.contentOffset = CGPoint(x: 0, y: newOffset)
+            }
+        }
+    }
+    
+    // MARK: - Cleanup
+    
+    public func cleanup() {
+        stopInteractiveTracking()
+        trackedScrollView?.panGestureRecognizer.removeTarget(self, action: #selector(handleScrollViewPan(_:)))
+        NotificationCenter.default.removeObserver(self)
+        self._keyboardAccessoryView = nil
+        self.contentView = nil
+        self.trackedScrollView = nil
+        self.scrollViewRelayoutCallback = nil
+        self.resignFirstResponder()
+    }
+    
+    deinit {
+        cleanup()
+    }
+}
+
+/**
+ * Custom input accessory container that properly sizes itself and supports dynamic height.
+ * Uses an internal height constraint which is the reliable way to resize inputAccessoryViews.
+ * Extends UIInputView with .keyboard style so the background matches the system keyboard exactly.
+ */
+class InputAccessoryContainerView: UIInputView {
+
+    var safeAreaBottomInset: CGFloat = 0
+    var contentHeight: CGFloat = 48
+
+    // Direct reference to the NativeScript content view
+    weak var contentViewRef: UIView?
+
+    // Internal height constraint - the reliable mechanism for inputAccessoryView resizing
+    private var heightConstraint: NSLayoutConstraint!
+
+    init(frame: CGRect) {
+        // .keyboard style gives the exact same translucent blur as the system keyboard.
+        // No separate UIVisualEffectView needed — the accessory blends seamlessly.
+        super.init(frame: frame, inputViewStyle: .keyboard)
+
+        self.allowsSelfSizing = true
+
+        // Create an internal height constraint.
+        // The keyboard system monitors this to resize the accessory view.
+        self.translatesAutoresizingMaskIntoConstraints = false
+        heightConstraint = self.heightAnchor.constraint(equalToConstant: frame.size.height)
+        heightConstraint.priority = .required
+        heightConstraint.isActive = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func updateHeightConstraint(_ newHeight: CGFloat) {
+        heightConstraint.constant = newHeight
+        invalidateIntrinsicContentSize()
+        superview?.setNeedsLayout()
+        superview?.layoutIfNeeded()
+    }
+
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: heightConstraint.constant)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Enforce content view positioning on every layout pass.
+        if let contentView = contentViewRef {
+            contentView.frame = CGRect(x: 0, y: 0, width: bounds.width, height: contentHeight)
+        }
+    }
+
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        if #available(iOS 11.0, *) {
+            insetsLayoutMarginsFromSafeArea = false
+        }
+    }
+
+    override var safeAreaInsets: UIEdgeInsets {
+        return .zero
+    }
+}
+
+/**
+ * Weak-reference proxy for CADisplayLink to avoid a retain cycle.
+ * CADisplayLink retains its target, so using `self` directly would
+ * prevent KeyboardTrackingView from being deallocated.
+ */
+private class DisplayLinkProxy: NSObject {
+    weak var target: KeyboardTrackingView?
+    init(_ target: KeyboardTrackingView) { self.target = target }
+    @objc func tick() { target?.trackKeyboardPosition() }
+}

--- a/packages/input-accessory/project.json
+++ b/packages/input-accessory/project.json
@@ -1,0 +1,65 @@
+{
+	"name": "input-accessory",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/input-accessory",
+	"targets": {
+		"build": {
+			"executor": "@nx/js:tsc",
+			"options": {
+				"outputPath": "dist/packages/input-accessory",
+				"tsConfig": "packages/input-accessory/tsconfig.json",
+				"packageJson": "packages/input-accessory/package.json",
+				"main": "packages/input-accessory/index.d.ts",
+				"assets": [
+					"packages/input-accessory/*.md",
+					"packages/input-accessory/index.d.ts",
+					"LICENSE",
+					{
+						"glob": "**/*",
+						"input": "packages/input-accessory/platforms/",
+						"output": "./platforms/"
+					}
+				],
+				"dependsOn": [
+					{
+						"target": "build.all",
+						"projects": "dependencies"
+					}
+				]
+			}
+		},
+		"build.all": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["node tools/scripts/build-finish.ts input-accessory"],
+				"parallel": false
+			},
+			"outputs": ["{workspaceRoot}/dist/packages/input-accessory"],
+			"dependsOn": [
+				{
+					"target": "build.all",
+					"projects": "dependencies"
+				},
+				{
+					"target": "build",
+					"projects": "self"
+				}
+			]
+		},
+		"focus": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx g @nativescript/plugin-tools:focus-packages input-accessory"],
+				"parallel": false
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:eslint",
+			"options": {
+				"lintFilePatterns": ["packages/input-accessory/**/*.ts"]
+			}
+		}
+	},
+	"tags": []
+}

--- a/packages/input-accessory/references.d.ts
+++ b/packages/input-accessory/references.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../references.d.ts" />

--- a/packages/input-accessory/tsconfig.json
+++ b/packages/input-accessory/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"rootDir": "."
+	},
+	"exclude": ["**/*.spec.ts", "**/*.test.ts", "angular"],
+	"include": ["**/*.ts", "references.d.ts"]
+}

--- a/packages/input-accessory/typings/android.d.ts
+++ b/packages/input-accessory/typings/android.d.ts
@@ -1,0 +1,25 @@
+// Native Android type declarations for @nativescript/input-accessory
+
+declare namespace org {
+	namespace nativescript {
+		namespace inputaccessory {
+			class KeyboardAccessoryHelper {
+				constructor(activity: android.app.Activity, inputContainer: android.view.View, scrollView: android.view.View, inputContainerHeight: number);
+
+				setup(callback: org.nativescript.inputaccessory.KeyboardAccessoryHelper.KeyboardStateCallback): void;
+				updateAccessoryHeight(newHeightPx: number): void;
+				dismissKeyboard(): void;
+				showKeyboard(): void;
+				scrollToBottom(): void;
+				clampScrollPosition(): void;
+				cleanup(): void;
+			}
+
+			namespace KeyboardAccessoryHelper {
+				class KeyboardStateCallback {
+					constructor(implementation: { onKeyboardHeightChanged(heightPx: number, isAnimating: boolean): void; onKeyboardFullyShown(heightPx: number): void; onKeyboardFullyHidden(): void; onRelayoutScrollContent(): void });
+				}
+			}
+		}
+	}
+}

--- a/packages/input-accessory/typings/ios.d.ts
+++ b/packages/input-accessory/typings/ios.d.ts
@@ -1,0 +1,86 @@
+// Native iOS type declarations for @nativescript/input-accessory
+// Generated from KeyboardTrackingView.swift @objcMembers classes
+
+declare class InputAccessoryContainerView extends UIView {
+	static alloc(): InputAccessoryContainerView; // inherited from NSObject
+
+	static appearance(): InputAccessoryContainerView; // inherited from UIAppearance
+
+	/**
+	 * @since 8.0
+	 */
+	static appearanceForTraitCollection(trait: UITraitCollection): InputAccessoryContainerView; // inherited from UIAppearance
+
+	/**
+	 * @since 8.0
+	 * @deprecated 9.0
+	 */
+	static appearanceForTraitCollectionWhenContainedIn(trait: UITraitCollection, ContainerClass: typeof NSObject): InputAccessoryContainerView; // inherited from UIAppearance
+
+	/**
+	 * @since 9.0
+	 */
+	static appearanceForTraitCollectionWhenContainedInInstancesOfClasses(trait: UITraitCollection, containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]): InputAccessoryContainerView; // inherited from UIAppearance
+
+	/**
+	 * @since 5.0
+	 * @deprecated 9.0
+	 */
+	static appearanceWhenContainedIn(ContainerClass: typeof NSObject): InputAccessoryContainerView; // inherited from UIAppearance
+
+	/**
+	 * @since 9.0
+	 */
+	static appearanceWhenContainedInInstancesOfClasses(containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]): InputAccessoryContainerView; // inherited from UIAppearance
+
+	static new(): InputAccessoryContainerView; // inherited from NSObject
+}
+
+declare class KeyboardTrackingView extends UIView {
+	static alloc(): KeyboardTrackingView; // inherited from NSObject
+
+	static appearance(): KeyboardTrackingView; // inherited from UIAppearance
+
+	/**
+	 * @since 8.0
+	 */
+	static appearanceForTraitCollection(trait: UITraitCollection): KeyboardTrackingView; // inherited from UIAppearance
+
+	/**
+	 * @since 8.0
+	 * @deprecated 9.0
+	 */
+	static appearanceForTraitCollectionWhenContainedIn(trait: UITraitCollection, ContainerClass: typeof NSObject): KeyboardTrackingView; // inherited from UIAppearance
+
+	/**
+	 * @since 9.0
+	 */
+	static appearanceForTraitCollectionWhenContainedInInstancesOfClasses(trait: UITraitCollection, containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]): KeyboardTrackingView; // inherited from UIAppearance
+
+	/**
+	 * @since 5.0
+	 * @deprecated 9.0
+	 */
+	static appearanceWhenContainedIn(ContainerClass: typeof NSObject): KeyboardTrackingView; // inherited from UIAppearance
+
+	/**
+	 * @since 9.0
+	 */
+	static appearanceWhenContainedInInstancesOfClasses(containerTypes: NSArray<typeof NSObject> | (typeof NSObject)[]): KeyboardTrackingView; // inherited from UIAppearance
+
+	static new(): KeyboardTrackingView; // inherited from NSObject
+
+	cleanup(): void;
+
+	setScrollViewRelayoutCallback(callback: () => void): void;
+
+	setupWithInputContainerScrollViewHeight(inputContainer: UIView, scrollView: UIScrollView, height: number): void;
+
+	showKeyboardWithTextField(textField: UITextField): void;
+
+	setDismissingKeyboard(): void;
+
+	trackKeyboardPosition(): void;
+
+	updateHeight(newHeight: number): void;
+}

--- a/tools/assets/App_Resources/Android/app.gradle
+++ b/tools/assets/App_Resources/Android/app.gradle
@@ -31,11 +31,11 @@ dependencies {
 }
 
 android {  
-  compileSdkVersion 34
-  buildToolsVersion "34.0.0"
+  compileSdkVersion 35
+  buildToolsVersion "35.0.0"
   defaultConfig {  
     minSdkVersion 24
-    targetSdkVersion 34
+    targetSdkVersion 35
     generatedDensities = []
   }  
   aaptOptions {  

--- a/tools/demo/index.ts
+++ b/tools/demo/index.ts
@@ -23,6 +23,7 @@ export * from './google-mobile-ads';
 export * from './google-signin';
 export * from './haptics';
 export * from './imagepicker';
+export * from './input-accessory';
 export * from './ios-security';
 export * from './iqkeyboardmanager';
 export * from './keyboard-toolbar';

--- a/tools/demo/input-accessory/index.ts
+++ b/tools/demo/input-accessory/index.ts
@@ -1,0 +1,8 @@
+import { DemoSharedBase } from '../utils';
+import {} from '@nativescript/input-accessory';
+
+export class DemoSharedInputAccessory extends DemoSharedBase {
+	testIt() {
+		console.log('test input-accessory!');
+	}
+}

--- a/tools/workspace-scripts.js
+++ b/tools/workspace-scripts.js
@@ -309,6 +309,13 @@ module.exports = {
 					description: '@nativescript/google-mobile-ads: Build',
 				},
 			},
+			// @nativescript/input-accessory
+			'input-accessory': {
+				build: {
+					script: 'nx run input-accessory:build.all',
+					description: '@nativescript/input-accessory: Build',
+				},
+			},
 			'build-all': {
 				script: 'nx run-many --target=build.all --all',
 				description: 'Build all packages',
@@ -470,6 +477,10 @@ module.exports = {
 			'google-mobile-ads': {
 				script: 'nx run google-mobile-ads:focus',
 				description: 'Focus on @nativescript/google-mobile-ads',
+			},
+			'input-accessory': {
+				script: 'nx run input-accessory:focus',
+				description: 'Focus on @nativescript/input-accessory',
 			},
 			reset: {
 				script: 'nx g @nativescript/plugin-tools:focus-packages',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -65,7 +65,8 @@
 			"@nativescript/social-share": ["packages/social-share/index.d.ts"],
 			"@nativescript/theme-switcher": ["packages/theme-switcher/index.ts"],
 			"@nativescript/twitter": ["packages/twitter/index.d.ts"],
-			"@nativescript/zip": ["packages/zip/index.d.ts"]
+			"@nativescript/zip": ["packages/zip/index.d.ts"],
+			"@nativescript/input-accessory": ["packages/input-accessory/index.d.ts"]
 		}
 	},
 	"exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
- `@nativescript/input-accessory`: docked input bar, interactive dismiss, and auto-scroll on both iOS and Android. Commonly used with chat interfaces, search focused views, or anywhere you want a keyboard-attached input experience.

https://x.com/NativeScript/status/2020867527803285557

Works for Android now as well.