### PR TITLE
feat(datetimepicker): ios permitted arrow directions

### DIFF
--- a/packages/datetimepicker/common.ts
+++ b/packages/datetimepicker/common.ts
@@ -37,6 +37,7 @@ export interface PickerOptions {
 	title?: string;
 	okButtonText?: string;
 	cancelButtonText?: string;
+	iosPermittedArrowDirections?: number;
 }
 
 export class DateTimePickerStyleBase implements DateTimePickerStyleDefinition {

--- a/packages/datetimepicker/index.d.ts
+++ b/packages/datetimepicker/index.d.ts
@@ -103,6 +103,12 @@ export interface PickerOptions {
 	 * Text for the cancel button of the picker (default is Cancel on iOS, localized version of Cancel on android (based on the devices locale settings)).
 	 */
 	cancelButtonText?: string;
+
+	/**
+	 * iOS only: permitted arrow directions
+	 * Defaults to `UIPopoverArrowDirection.Any` when not provided.
+	 */
+	iosPermittedArrowDirections?: number;
 }
 
 /**

--- a/packages/datetimepicker/index.ios.ts
+++ b/packages/datetimepicker/index.ios.ts
@@ -28,7 +28,7 @@ export class DateTimePicker extends DateTimePickerBase {
 			DateTimePicker._nativeDialog = DateTimePicker._createNativeDialog(nativeDatePicker, options, style, (result) => {
 				resolve(result);
 			});
-			DateTimePicker._showNativeDialog(DateTimePicker._nativeDialog, nativeDatePicker, style);
+			DateTimePicker._showNativeDialog(DateTimePicker._nativeDialog, nativeDatePicker, options, style);
 		});
 		return pickDate;
 	}
@@ -39,7 +39,7 @@ export class DateTimePicker extends DateTimePickerBase {
 			DateTimePicker._nativeDialog = DateTimePicker._createNativeDialog(nativeTimePicker, options, style, (result) => {
 				resolve(result);
 			});
-			DateTimePicker._showNativeDialog(DateTimePicker._nativeDialog, nativeTimePicker, style);
+			DateTimePicker._showNativeDialog(DateTimePicker._nativeDialog, nativeTimePicker, options, style);
 		});
 		return pickTime;
 	}
@@ -158,7 +158,7 @@ export class DateTimePicker extends DateTimePickerBase {
 		return alertController;
 	}
 
-	static _showNativeDialog(nativeDialog: UIAlertController, nativePicker: UIDatePicker, style: DateTimePickerStyle) {
+	static _showNativeDialog(nativeDialog: UIAlertController, nativePicker: UIDatePicker, options: PickerOptions, style: DateTimePickerStyle) {
 		const app = UIApplication.sharedApplication;
 		const win = app.keyWindow || (app.windows && app.windows.count > 0 && app.windows.objectAtIndex(0));
 		let viewController = win.rootViewController;
@@ -170,7 +170,7 @@ export class DateTimePicker extends DateTimePickerBase {
 			if (nativeDialog.popoverPresentationController) {
 				nativeDialog.popoverPresentationController.sourceView = viewController.view;
 				nativeDialog.popoverPresentationController.sourceRect = CGRectMake(viewController.view.bounds.size.width / 2.0, viewController.view.bounds.size.height / 2.0, 1.0, 1.0);
-				nativeDialog.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.Any;
+				nativeDialog.popoverPresentationController.permittedArrowDirections = options && options.iosPermittedArrowDirections !== undefined ? options.iosPermittedArrowDirections : UIPopoverArrowDirection.Any;
 			}
 
 			viewController.presentViewControllerAnimatedCompletion(nativeDialog, true, () => {});


### PR DESCRIPTION
## Description
Add iOS-specific `iosPermittedArrowDirections` option to datetimepicker to control the popover arrow direction when presenting the picker on iPad.

## Problem
Today, the popover arrow is fixed to the center of the screen on iOS 26+ and cannot be changed. This can cause issues if the ok button text size is extra large due to accessibility options.

## Solution
Expose a new iOS-only option `iosPermittedArrowDirections` on the shared `PickerOptions` interface. The value is forwarded from `pickDate` / `pickTime` into `_showNativeDialog` and applied to `popoverPresentationController.permittedArrowDirections`. When the option is not provided, behavior is unchanged (`UIPopoverArrowDirection.Any`). With "UIPopoverArrowDirection.Unknown" the arrow can now be hidden and result in a popup style picker in the center of the screen.

## Testing
- [x] Tested on multiple simulators with iOS 26 and iOS 17
- [x] Verified default behavior (option omitted) matches previous behavior
- [x] Verified both `pickDate` and `pickTime` honor the option
- [x] TypeScript compilation passes

## Platforms affected
- [x] iOS
- [ ] Android
