### PR TITLE
feat: widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [@nativescript/social-share](packages/social-share/README.md)
 - [@nativescript/theme-switcher](packages/theme-switcher/README.md)
 - [@nativescript/twitter](packages/twitter/README.md)
+- [@nativescript/widgets](packages/widgets/README.md)
 - [@nativescript/zip](packages/zip/README.md)
 
 # How to use?

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -42,7 +42,8 @@
 		"@nativescript/social-share": "file:../../packages/social-share",
 		"@nativescript/theme-switcher": "file:../../packages/theme-switcher",
 		"@nativescript/twitter": "file:../../packages/twitter",
-		"@nativescript/zip": "file:../../packages/zip"
+		"@nativescript/zip": "file:../../packages/zip",
+		"@nativescript/widgets": "file:../../packages/widgets"
 	},
 	"devDependencies": {
 		"@nativescript/android": "~9.0.0",

--- a/apps/demo/src/main-page.xml
+++ b/apps/demo/src/main-page.xml
@@ -1,5 +1,6 @@
 
 <Button text="google-mobile-ads" tap="{{ viewDemo }}" class="btn btn-primary view-demo"/><Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo" class="page">
+<Button text="widgets" tap="{{ viewDemo }}" class="btn btn-primary rounded view-demo"/>
   <Page.actionBar>
     <ActionBar title="Plugin Demos" icon="" class="action-bar"/>
   </Page.actionBar>

--- a/apps/demo/src/plugin-demos/widgets.ts
+++ b/apps/demo/src/plugin-demos/widgets.ts
@@ -1,0 +1,10 @@
+import { Observable, EventData, Page } from '@nativescript/core';
+import { DemoSharedWidgets } from '@demo/shared';
+import {} from '@nativescript/widgets';
+
+export function navigatingTo(args: EventData) {
+	const page = <Page>args.object;
+	page.bindingContext = new DemoModel();
+}
+
+export class DemoModel extends DemoSharedWidgets {}

--- a/apps/demo/src/plugin-demos/widgets.xml
+++ b/apps/demo/src/plugin-demos/widgets.xml
@@ -1,0 +1,14 @@
+<Page xmlns="http://schemas.nativescript.org/tns.xsd" navigatingTo="navigatingTo" class="page">
+    <Page.actionBar>
+        <ActionBar title="widgets" icon="" class="action-bar">
+        </ActionBar>
+    </Page.actionBar>
+    <StackLayout class="p-20">
+        <ScrollView class="h-full">
+          <StackLayout>
+            <Button text="Test widgets" tap="{{ testIt }}" class="btn btn-primary"/>
+
+          </StackLayout>
+        </ScrollView>
+    </StackLayout>
+</Page>

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -51,7 +51,8 @@
 			"@nativescript/google-mobile-ads/angular": ["../../packages/google-mobile-ads/angular/index.ts"],
 			"@nativescript/google-maps-utils": ["../../packages/google-maps-utils/index.d.ts"],
 			"@nativescript/keyboard-toolbar": ["../../packages/keyboard-toolbar/index.d.ts"],
-			"@nativescript/input-accessory": ["../../packages/input-accessory/index.d.ts"]
+			"@nativescript/input-accessory": ["../../packages/input-accessory/index.d.ts"],
+			"@nativescript/widgets": ["../../packages/widgets/index.d.ts"]
 		}
 	}
 }

--- a/packages/widgets/.eslintrc.json
+++ b/packages/widgets/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*", "node_modules/**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/packages/widgets/README.md
+++ b/packages/widgets/README.md
@@ -1,0 +1,411 @@
+# @nativescript/widgets
+
+Build and drive **home‑screen widgets** from your NativeScript app.
+
+On **Android** this plugin lets you construct [`RemoteViews`](https://developer.android.com/reference/android/widget/RemoteViews) trees to respond to the App Widget lifecycle (enable / update / delete / disable), and push updates to placed widgets — including periodic background refreshes powered by `WorkManager`.
+
+> **Platform support:** Android only, today. iOS home‑screen widgets and Live Activities are generated as native SwiftUI extensions by the NativeScript CLI (`ns widget ios`) and do **not** use this package's JS API — see [iOS](#ios) below. Importing `@nativescript/widgets` on iOS resolves to an empty module.
+
+```bash
+npm install @nativescript/widgets
+```
+
+Requires a CLI with widget scaffolding support (`ns widget android`).
+
+---
+
+## Table of contents
+
+- [How it works](#how-it-works)
+- [Quick start](#quick-start)
+  - [1. Scaffold the widget](#1-scaffold-the-widget)
+  - [2. Provide an initial layout](#2-provide-an-initial-layout)
+  - [3. Register a listener in your app](#3-register-a-listener-in-your-app)
+- [The widget lifecycle](#the-widget-lifecycle)
+- [Building RemoteViews](#building-remoteviews)
+  - [View classes](#view-classes)
+  - [Text](#text)
+  - [Images](#images)
+  - [Remote images (from a URL)](#remote-images-from-a-url)
+  - [Containers](#containers)
+  - [Click handling](#click-handling)
+  - [Sizing & visibility](#sizing--visibility)
+- [Pushing updates to the widget](#pushing-updates-to-the-widget)
+- [Periodic updates & the update interval](#periodic-updates--the-update-interval)
+- [API reference](#api-reference)
+- [iOS](#ios)
+- [License](#license)
+
+---
+
+## How it works
+
+An Android App Widget is driven by an `AppWidgetProvider` (a `BroadcastReceiver`) declared in the manifest. This plugin ships a base provider, `org.nativescript.widgets.AppWidgetProvider`, that forwards every system callback into your JavaScript through a listener you register with `registerWidgetListener()`.
+
+The flow for a single widget provider looks like this:
+
+```
+Android system / WorkManager
+          │
+          ▼
+org.nativescript.widgets.AppWidgetProvider  (the receiver in your manifest)
+          │  forwards callbacks
+          ▼
+AppWidgetManager  (native singleton, keyed by provider class name)
+          │  notifies the registered listener
+          ▼
+registerWidgetListener(provider, { onUpdate, onUpdateAsync, ... })   ← your JS
+          │  you build a RemoteViews tree
+          ▼
+widgetManager.updateAppWidget(id, remoteViews)   ← pushes pixels to the widget
+```
+
+Two things are worth internalizing up front:
+
+- **Widgets render in a *different* process** (the launcher's). You never hand it live views — you hand it a `RemoteViews` description, and the launcher inflates it. That is why the API is a command/description builder rather than the normal NativeScript view layer.
+- **The plugin uses `WorkManager`, not `android:updatePeriodMillis`, for periodic refresh.** The generated `appwidget-provider` XML sets `updatePeriodMillis="0"` and the base provider schedules a periodic worker instead. This means periodic work survives across reboots and app updates, but is still subject to WorkManager's **15‑minute minimum** interval.
+
+---
+
+## Quick start
+
+### 1. Scaffold the widget
+
+Run the CLI generator and answer the prompts:
+
+```bash
+ns widget android
+```
+
+You'll be asked for a name, description, update interval, resize mode, min width/height, initial layout, package name and provider class name. With the defaults, this generates the following into `App_Resources/Android`:
+
+| File | Purpose |
+| --- | --- |
+| `src/main/java/<pkg>/<Name>WidgetProvider.kt` | Your provider — a subclass of `org.nativescript.widgets.AppWidgetProvider`. |
+| `src/main/res/xml/ns_<name>_widget_info.xml` | The `appwidget-provider` metadata (sizing, resize mode, initial layout). |
+| `src/main/res/values/ns_widgets_strings_info.xml` | The widget description string. |
+| `AndroidManifest.xml` | A `<receiver>` for your provider, wrapped in `<!-- BEGIN/END NativeScript Widget: <name> -->` markers, with `APPWIDGET_UPDATE` and `BOOT_COMPLETED` intent filters. |
+
+The generated provider is tiny — its only job is to exist in the manifest and (optionally) set the refresh interval:
+
+```kotlin
+package com.example.myapp
+import org.nativescript.widgets.AppWidgetProvider
+
+class SampleWidgetProvider : AppWidgetProvider() {
+    override val interval = 900000L // 15 minutes, in milliseconds
+}
+```
+
+The generated `appwidget-provider` XML also carries a marker meta‑data entry so tooling can recognize plugin‑managed widgets:
+
+```xml
+<meta-data
+    android:name="org.nativescript.widgets.MANAGED_WIDGET"
+    android:value="true"/>
+```
+
+### 2. The initial layout
+
+Android requires the `appwidget-provider` to reference an **initial layout** — the placeholder shown after the widget is dropped on the home screen but *before* your first update runs. The generator defaults `android:initialLayout` to `@layout/ns_remote_views_linear_layout`, an empty vertical `LinearLayout` that ships with this plugin, so the default widget builds and renders out of the box.
+
+To customize the placeholder, either point `android:initialLayout` at another layout this plugin ships (e.g. `@layout/ns_remote_views_frame_layout`) or add your own layout under `App_Resources/Android/src/main/res/layout/` and reference it.
+
+> All layouts shipped by the plugin use `@id/ns_remote_view_root` as their root view id. When you build a `RemoteViews` node, the plugin applies its commands to that root id, so any placeholder you supply should follow the same convention if you want the very first frame to be styleable.
+
+### 3. Register a listener in your app
+
+Register the listener **at app bootstrap** (e.g. the top of `app.ts` / `main.ts`). Android may spin up your process solely to deliver a widget broadcast, so the listener must be wired up as the runtime starts — not lazily from a page that may never open.
+
+The `provider` string is the **fully qualified class name** of the provider you generated.
+
+```ts
+import { registerWidgetListener, LinearLayout, TextView } from '@nativescript/widgets';
+import { Color } from '@nativescript/core';
+
+const PROVIDER = 'com.example.myapp.SampleWidgetProvider';
+
+registerWidgetListener(PROVIDER, {
+  onUpdate({ appWidgetIds, widgetManager }) {
+    const root = new LinearLayout();
+
+    const title = new TextView();
+    title.native.setText('Hello from NativeScript');
+    title.native.setTextColor(new Color('#ffffff').android);
+    root.addView(title);
+
+    const rv = root.toAndroidRemoteViews(); // -> AndroidRemoteViews
+    appWidgetIds.forEach((id) => {
+      widgetManager.native.updateAppWidget(id, rv.native);
+    });
+  },
+});
+```
+
+Add the widget to your home screen (long‑press the launcher → Widgets) and it will render on the first `onUpdate`.
+
+---
+
+## The widget lifecycle
+
+`registerWidgetListener(provider, listener)` accepts any subset of these callbacks:
+
+| Callback | When it fires | Thread | Typical use |
+| --- | --- | --- | --- |
+| `onEnabled(provider)` | First instance of the widget is added. | Main | One‑time setup. The base provider also schedules the periodic worker here. |
+| `onUpdate({ provider, appWidgetIds, manager, widgetManager })` | System requests an update (widget added, host asks to refresh). | Main | Fast, **local** rendering for an immediate first paint. Do **not** do network/disk work here. |
+| `onUpdateAsync({ provider, appWidgetIds, manager, widgetManager })` | Fired right after each `onUpdate`, and on **every periodic tick**. | Background (`WorkManager`) | Network calls, image loading, database reads — anything slow. |
+| `onDeleted({ provider, appWidgetIds })` | One or more widget instances are removed. | Main | Clean up per‑instance state. |
+| `onDisabled(provider)` | The last instance is removed. | Main | Tear down. The base provider cancels the periodic worker here. |
+
+Notes on behavior:
+
+- On a system update the base provider calls `onUpdate` synchronously **and** enqueues a one‑time background worker that fires `onUpdateAsync`. So for most widgets you can paint a cheap placeholder in `onUpdate` and fill in the real (possibly remote) content in `onUpdateAsync`.
+- Periodic ticks only fire `onUpdateAsync` (never `onUpdate`).
+- If a periodic tick runs and there are **no** widget instances left, the worker cancels itself.
+- `onUpdateAsync` is only invoked if you actually provide it — omit it if you don't need background work.
+
+The event payload:
+
+- `appWidgetIds: number[]` — the widget instance ids you should update.
+- `widgetManager` — wraps the native `android.appwidget.AppWidgetManager`. Call `widgetManager.native.updateAppWidget(id, remoteViews)` to push a frame.
+- `manager` — wraps the plugin's per‑provider `RemoteViewsManager` (the node/tree store). You usually don't need it if you build a fresh tree each update.
+- `provider` — the provider class name.
+
+Call `unregisterWidgetListener(provider)` to remove a listener.
+
+---
+
+## Building RemoteViews
+
+The JS classes are **thin wrappers** over `org.nativescript.widgets.RemoteViews.*`. Container helpers (`addView` / `removeView`) and `toAndroidRemoteViews()` are exposed directly on the wrapper; everything else (text, images, sizing, click intents) is called through the wrapped native node via `.native`.
+
+```ts
+const tv = new TextView();
+tv.native.setText('Total: 42');          // fluent native API
+tv.native.setTextColor(0xffffffff);       // ARGB int
+```
+
+> **TypeScript note:** the wrapper's `.native` getter is typed as the base `org.nativescript.widgets.RemoteViews`, which does not surface the leaf setters (`setText`, `setImageUrl`, …). At runtime the instance is the correct subclass, so the calls work — add a cast (`(tv.native as any).setText(...)`) if the compiler complains, or reach for the fully‑typed `org.nativescript.widgets.RemoteViews.*` classes directly.
+
+Every node takes an optional stable `id` string in its constructor (`new TextView('total')`). Omit it and one is generated.
+
+### View classes
+
+| JS class | Kotlin layout | Notes |
+| --- | --- | --- |
+| `TextView` | `TextView` | `setText`, `setTextColor` |
+| `Button` | `Button` | `setText`, `setTextColor` |
+| `TextClock` | `TextClock` | `setText`, `setTextColor` |
+| `Chronometer` | `Chronometer` | |
+| `ImageView` | `ImageView` | `setImageResource` / `setImageURI` / `setImageBitmap` / `setImageUrl` |
+| `ImageButton` | `ImageButton` | same image setters as `ImageView` |
+| `ProgressBar` | `ProgressBar` | |
+| `LinearLayout` | `LinearLayout` | container (`addView` / `removeView`) |
+| `RelativeLayout` | `RelativeLayout` | container |
+| `FrameLayout` | `FrameLayout` | container |
+| `GridLayout` | `GridLayout` | container |
+| `GridView` | `GridView` | container |
+| `StackView` | `StackView` | container |
+| `ListView` | `ListView` | collection view |
+| `AdapterViewFlipper` | `AdapterViewFlipper` | |
+
+All of them extend the base `RemoteViews` wrapper, which exposes `.native` and `.toAndroidRemoteViews(packageName?)`.
+
+### Text
+
+```ts
+const label = new TextView('label');
+label.native.setText('Weather');
+label.native.setTextColor(new Color('#222222').android);
+```
+
+### Images
+
+```ts
+import { ImageSource } from '@nativescript/core';
+
+const icon = new ImageView('icon');
+icon.native.setImageResource(android.R.drawable.ic_dialog_info); // drawable resource id
+// or a bitmap you already have:
+// icon.native.setImageBitmap(ImageSource.fromFileSync(path).android);
+```
+
+### Remote images (from a URL)
+
+`setImageUrl` records the URL but does **not** fetch it — fetching happens when you call `resolveRemoteResources()`, which performs a **blocking** network read. Only do this from `onUpdateAsync` (the background worker), never from `onUpdate`.
+
+```ts
+import { registerWidgetListener, LinearLayout, ImageView } from '@nativescript/widgets';
+
+registerWidgetListener(PROVIDER, {
+  onUpdateAsync({ appWidgetIds, widgetManager }) {
+    const root = new LinearLayout();
+    const img = new ImageView();
+    img.native.setImageUrl('https://example.com/chart.png');
+    root.addView(img);
+
+    root.native.resolveRemoteResources(); // fetch remote images (blocking, safe on worker thread)
+
+    const rv = root.toAndroidRemoteViews();
+    appWidgetIds.forEach((id) => widgetManager.native.updateAppWidget(id, rv.native));
+  },
+});
+```
+
+`resolveRemoteResources()` walks the whole tree attached to the node's manager and swaps each unresolved `setImageUrl` for the fetched bitmap (dropping any that fail to load).
+
+### Containers
+
+Container nodes build a tree with `addView` / `removeView`. Children are linked through a shared manager, and `toAndroidRemoteViews()` on the root recursively builds the whole tree.
+
+```ts
+const root = new LinearLayout('root');
+
+const title = new TextView('title');
+title.native.setText('Today');
+
+const value = new TextView('value');
+value.native.setText('72°');
+
+root.addView(title);
+root.addView(value);
+
+const rv = root.toAndroidRemoteViews();
+```
+
+### Click handling
+
+Attach a `PendingIntent` to any node to make it tappable — e.g. to open your app:
+
+```ts
+import { Utils } from '@nativescript/core';
+
+const ctx = Utils.android.getApplicationContext();
+const launch = ctx.getPackageManager().getLaunchIntentForPackage(ctx.getPackageName());
+
+const flags =
+  android.app.PendingIntent.FLAG_UPDATE_CURRENT |
+  android.app.PendingIntent.FLAG_IMMUTABLE;
+
+const pi = android.app.PendingIntent.getActivity(ctx, 0, launch, flags);
+
+const button = new Button('open');
+button.native.setText('Open app');
+button.native.setOnClickPendingIntent(pi);
+```
+
+### Sizing & visibility
+
+```ts
+// Visibility uses android.view.View constants: VISIBLE(0) / INVISIBLE(4) / GONE(8)
+node.native.setVisibility(android.view.View.GONE);
+
+// setBackgroundColor takes an ARGB int
+node.native.setBackgroundColor(new Color('#1e88e5').android);
+
+// Explicit layout sizing (Android 12 / API 31+ only — no-op on older devices)
+const DIP = android.util.TypedValue.COMPLEX_UNIT_DIP;
+node.native.setSize(120, DIP, 60, DIP);
+// or individually:
+node.native.setWidth(120, DIP);
+node.native.setHeight(60, DIP);
+```
+
+Lower‑level passthroughs (`setInt`, `setBoolean`, `setString`, `setFloat`, `setLong`, `setShort`, `setByte`) map straight onto the corresponding `RemoteViews.set*` methods, letting you call any remotable setter by method name:
+
+```ts
+node.native.setBoolean('setEnabled', true);
+node.native.setInt('setMaxLines', 2);
+```
+
+---
+
+## Pushing updates to the widget
+
+Regardless of how you build the tree, the last step is always the same: build the native `RemoteViews` and hand it to the widget manager for each instance id.
+
+```ts
+const rv = root.toAndroidRemoteViews();      // AndroidRemoteViews (wraps android.widget.RemoteViews)
+appWidgetIds.forEach((id) => {
+  widgetManager.native.updateAppWidget(id, rv.native);
+});
+```
+
+`toAndroidRemoteViews(packageName?)` defaults to your app's package name; pass one explicitly only if you're targeting a different package's resources.
+
+---
+
+## Periodic updates & the update interval
+
+- The interval is defined on your provider via `override val interval = <ms>` (defaults to `900000` = 15 minutes).
+- `WorkManager` enforces a **15‑minute minimum** for periodic work. Values below that are clamped by the platform — you cannot refresh a widget faster than every 15 minutes via the periodic path.
+- The periodic worker is (re)scheduled in `onEnabled` and cancelled in `onDisabled`. It also self‑cancels if no widget instances remain.
+- Because scheduling uses `WorkManager` (and the manifest receiver listens for `BOOT_COMPLETED`), periodic updates resume after a reboot or an app update.
+- For updates that need to happen *now* (e.g. in response to app activity), request a system update yourself and let it flow through `onUpdate` / `onUpdateAsync`:
+
+```ts
+import { Utils } from '@nativescript/core';
+
+const ctx = Utils.android.getApplicationContext();
+const mgr = android.appwidget.AppWidgetManager.getInstance(ctx);
+const component = new android.content.ComponentName(ctx, 'com.example.myapp.SampleWidgetProvider');
+const ids = mgr.getAppWidgetIds(component);
+
+const intent = new android.content.Intent(android.appwidget.AppWidgetManager.ACTION_APPWIDGET_UPDATE);
+intent.setComponent(component);
+intent.putExtra(android.appwidget.AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
+ctx.sendBroadcast(intent);
+```
+
+---
+
+## API reference
+
+### Functions
+
+```ts
+function registerWidgetListener(provider: string, listener: IWidgetListener): void;
+function unregisterWidgetListener(provider: string): void;
+```
+
+```ts
+interface IWidgetListener {
+  onEnabled?(provider: string): void;
+  onUpdate?(e: { provider: string; appWidgetIds: number[]; manager: WidgetManager; widgetManager: AndroidWidgetManager }): void;
+  onUpdateAsync?(e: { provider: string; appWidgetIds: number[]; manager: WidgetManager; widgetManager: AndroidWidgetManager }): void;
+  onDeleted?(e: { provider: string; appWidgetIds: number[] }): void;
+  onDisabled?(provider: string): void;
+}
+```
+
+### Classes
+
+- `RemoteViews` — base wrapper. `get native`, `toAndroidRemoteViews(packageName?): AndroidRemoteViews`.
+- `AndroidRemoteViews` — wraps `android.widget.RemoteViews`; `get native`.
+- View nodes: `TextView`, `Button`, `TextClock`, `Chronometer`, `ImageView`, `ImageButton`, `ProgressBar`, `ListView`, `AdapterViewFlipper`.
+- Containers (add `addView(v)` / `removeView(v)`): `LinearLayout`, `RelativeLayout`, `FrameLayout`, `GridLayout`, `GridView`, `StackView`.
+- `WidgetManager` — wraps the per‑provider native manager; `get native`.
+- `AndroidWidgetManager` — wraps `android.appwidget.AppWidgetManager`; `get native`.
+
+For the complete surface of the underlying native `RemoteViews` API (all `set*` commands, `Command` types, `RemoteViewsManager`), see [`typings/org.nativescript.widgets.d.ts`](./typings/org.nativescript.widgets.d.ts).
+
+---
+
+## iOS
+
+There is no JS API for iOS widgets in this package (the iOS entry point is empty). iOS home‑screen widgets and Live Activities are generated by the CLI as native SwiftUI extensions:
+
+```bash
+ns widget ios   # macOS only
+```
+
+This scaffolds a WidgetKit extension (and, for Live Activities, a shared Swift model package) under `App_Resources/iOS/extensions` plus an `AppleWidgetUtils` Swift helper you call from JS to start/update activities, reload timelines, and read/write shared App Group data. Those files are self‑contained and documented inline where they're generated.
+
+---
+
+## License
+
+Apache License Version 2.0
+</content>
+</invoke>

--- a/packages/widgets/README.md
+++ b/packages/widgets/README.md
@@ -130,8 +130,8 @@ registerWidgetListener(PROVIDER, {
     const root = new LinearLayout();
 
     const title = new TextView();
-    title.native.setText('Hello from NativeScript');
-    title.native.setTextColor(new Color('#ffffff').android);
+    title.setText('Hello from NativeScript');
+    title.setTextColor(new Color('#ffffff').android);
     root.addView(title);
 
     const rv = root.toAndroidRemoteViews(); // -> AndroidRemoteViews
@@ -182,11 +182,11 @@ The JS classes are **thin wrappers** over `org.nativescript.widgets.RemoteViews.
 
 ```ts
 const tv = new TextView();
-tv.native.setText('Total: 42');          // fluent native API
-tv.native.setTextColor(0xffffffff);       // ARGB int
+tv.setText('Total: 42');          // fluent wrapper API
+tv.setTextColor(0xffffffff);      // ARGB int
 ```
 
-> **TypeScript note:** the wrapper's `.native` getter is typed as the base `org.nativescript.widgets.RemoteViews`, which does not surface the leaf setters (`setText`, `setImageUrl`, …). At runtime the instance is the correct subclass, so the calls work — add a cast (`(tv.native as any).setText(...)`) if the compiler complains, or reach for the fully‑typed `org.nativescript.widgets.RemoteViews.*` classes directly.
+Most common operations are exposed directly on the JS wrapper (`setText`, `setImageUrl`, `setVisibility`, `setSize`, and more). The `.native` handle is still available for platform-level interop when needed.
 
 Every node takes an optional stable `id` string in its constructor (`new TextView('total')`). Omit it and one is generated.
 
@@ -216,8 +216,8 @@ All of them extend the base `RemoteViews` wrapper, which exposes `.native` and `
 
 ```ts
 const label = new TextView('label');
-label.native.setText('Weather');
-label.native.setTextColor(new Color('#222222').android);
+label.setText('Weather');
+label.setTextColor(new Color('#222222').android);
 ```
 
 ### Images
@@ -226,9 +226,9 @@ label.native.setTextColor(new Color('#222222').android);
 import { ImageSource } from '@nativescript/core';
 
 const icon = new ImageView('icon');
-icon.native.setImageResource(android.R.drawable.ic_dialog_info); // drawable resource id
+icon.setImageResource(android.R.drawable.ic_dialog_info); // drawable resource id
 // or a bitmap you already have:
-// icon.native.setImageBitmap(ImageSource.fromFileSync(path).android);
+// icon.setImageBitmap(ImageSource.fromFileSync(path).android);
 ```
 
 ### Remote images (from a URL)
@@ -242,10 +242,10 @@ registerWidgetListener(PROVIDER, {
   onUpdateAsync({ appWidgetIds, widgetManager }) {
     const root = new LinearLayout();
     const img = new ImageView();
-    img.native.setImageUrl('https://example.com/chart.png');
+    img.setImageUrl('https://example.com/chart.png');
     root.addView(img);
 
-    root.native.resolveRemoteResources(); // fetch remote images (blocking, safe on worker thread)
+    root.resolveRemoteResources(); // fetch remote images (blocking, safe on worker thread)
 
     const rv = root.toAndroidRemoteViews();
     appWidgetIds.forEach((id) => widgetManager.native.updateAppWidget(id, rv.native));
@@ -263,10 +263,10 @@ Container nodes build a tree with `addView` / `removeView`. Children are linked 
 const root = new LinearLayout('root');
 
 const title = new TextView('title');
-title.native.setText('Today');
+title.setText('Today');
 
 const value = new TextView('value');
-value.native.setText('72°');
+value.setText('72°');
 
 root.addView(title);
 root.addView(value);
@@ -291,32 +291,32 @@ const flags =
 const pi = android.app.PendingIntent.getActivity(ctx, 0, launch, flags);
 
 const button = new Button('open');
-button.native.setText('Open app');
-button.native.setOnClickPendingIntent(pi);
+button.setText('Open app');
+button.setOnClickPendingIntent(pi);
 ```
 
 ### Sizing & visibility
 
 ```ts
 // Visibility uses android.view.View constants: VISIBLE(0) / INVISIBLE(4) / GONE(8)
-node.native.setVisibility(android.view.View.GONE);
+node.setVisibility(android.view.View.GONE);
 
 // setBackgroundColor takes an ARGB int
-node.native.setBackgroundColor(new Color('#1e88e5').android);
+node.setBackgroundColor(new Color('#1e88e5').android);
 
 // Explicit layout sizing (Android 12 / API 31+ only — no-op on older devices)
 const DIP = android.util.TypedValue.COMPLEX_UNIT_DIP;
-node.native.setSize(120, DIP, 60, DIP);
+node.setSize(120, DIP, 60, DIP);
 // or individually:
-node.native.setWidth(120, DIP);
-node.native.setHeight(60, DIP);
+node.setWidth(120, DIP);
+node.setHeight(60, DIP);
 ```
 
 Lower‑level passthroughs (`setInt`, `setBoolean`, `setString`, `setFloat`, `setLong`, `setShort`, `setByte`) map straight onto the corresponding `RemoteViews.set*` methods, letting you call any remotable setter by method name:
 
 ```ts
-node.native.setBoolean('setEnabled', true);
-node.native.setInt('setMaxLines', 2);
+node.setBoolean('setEnabled', true);
+node.setInt('setMaxLines', 2);
 ```
 
 ---

--- a/packages/widgets/index.android.ts
+++ b/packages/widgets/index.android.ts
@@ -62,6 +62,81 @@ export class RemoteViews {
 		return this._remoteViews;
 	}
 
+	setOnClickPendingIntent(intent: android.app.PendingIntent) {
+		this.native.setOnClickPendingIntent(intent);
+		return this;
+	}
+
+	setBackgroundColor(value: number) {
+		this.native.setBackgroundColor(value);
+		return this;
+	}
+
+	setBoolean(method: string, value: boolean) {
+		this.native.setBoolean(method, value);
+		return this;
+	}
+
+	setByte(method: string, value: number) {
+		this.native.setByte(method, value);
+		return this;
+	}
+
+	setShort(method: string, value: number) {
+		this.native.setShort(method, value);
+		return this;
+	}
+
+	setInt(method: string, value: number) {
+		this.native.setInt(method, value);
+		return this;
+	}
+
+	setLong(method: string, value: number) {
+		this.native.setLong(method, value);
+		return this;
+	}
+
+	setFloat(method: string, value: number) {
+		this.native.setFloat(method, value);
+		return this;
+	}
+
+	setString(method: string, value: string) {
+		this.native.setString(method, value);
+		return this;
+	}
+
+	setSize(width: number, widthUnit: number, height: number, heightUnit: number) {
+		this.native.setSize(width, widthUnit, height, heightUnit);
+		return this;
+	}
+
+	setWidth(value: number, unit: number) {
+		this.native.setWidth(value, unit);
+		return this;
+	}
+
+	setHeight(value: number, unit: number) {
+		this.native.setHeight(value, unit);
+		return this;
+	}
+
+	setVisibility(visibility: number) {
+		this.native.setVisibility(visibility);
+		return this;
+	}
+
+	findViewById(id: string) {
+		const view = this.native.findViewById(id);
+		return view ? new RemoteViews(view) : null;
+	}
+
+	resolveRemoteResources() {
+		this.native.resolveRemoteResources();
+		return this;
+	}
+
 	toAndroidRemoteViews(packageName?: string): AndroidRemoteViews {
 		return new AndroidRemoteViews(this._remoteViews.build(packageName ?? Utils.android.getApplicationContext().getPackageName()));
 	}
@@ -71,17 +146,39 @@ export class AdapterViewFlipper extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.AdapterViewFlipper(id ?? null));
 	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.AdapterViewFlipper;
+	}
 }
 
 export class Button extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.Button(id ?? null));
 	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.Button;
+	}
+
+	setText(value: string) {
+		this.native.setText(value);
+		return this;
+	}
+
+	setTextColor(value: number) {
+		this.native.setTextColor(value);
+		return this;
+	}
 }
 
 export class Chronometer extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.Chronometer(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.Chronometer;
 	}
 }
 
@@ -143,11 +240,59 @@ export class ImageButton extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.ImageButton(id ?? null));
 	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.ImageButton;
+	}
+
+	setImageUrl(url: string) {
+		this.native.setImageUrl(url);
+		return this;
+	}
+
+	setImageResource(value: number) {
+		this.native.setImageResource(value);
+		return this;
+	}
+
+	setImageURI(value: android.net.Uri) {
+		this.native.setImageURI(value);
+		return this;
+	}
+
+	setImageBitmap(value: android.graphics.Bitmap) {
+		this.native.setImageBitmap(value);
+		return this;
+	}
 }
 
 export class ImageView extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.ImageView(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.ImageView;
+	}
+
+	setImageUrl(url: string) {
+		this.native.setImageUrl(url);
+		return this;
+	}
+
+	setImageResource(value: number) {
+		this.native.setImageResource(value);
+		return this;
+	}
+
+	setImageURI(value: android.net.Uri) {
+		this.native.setImageURI(value);
+		return this;
+	}
+
+	setImageBitmap(value: android.graphics.Bitmap) {
+		this.native.setImageBitmap(value);
+		return this;
 	}
 }
 
@@ -173,11 +318,19 @@ export class ListView extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.ListView(id ?? null));
 	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.ListView;
+	}
 }
 
 export class ProgressBar extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.ProgressBar(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.ProgressBar;
 	}
 }
 
@@ -221,11 +374,39 @@ export class TextView extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.TextView(id ?? null));
 	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.TextView;
+	}
+
+	setText(value: string) {
+		this.native.setText(value);
+		return this;
+	}
+
+	setTextColor(value: number) {
+		this.native.setTextColor(value);
+		return this;
+	}
 }
 
 export class TextClock extends RemoteViews {
 	constructor(id?: string) {
 		super(new org.nativescript.widgets.RemoteViews.TextClock(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.TextClock;
+	}
+
+	setText(value: string) {
+		this.native.setText(value);
+		return this;
+	}
+
+	setTextColor(value: number) {
+		this.native.setTextColor(value);
+		return this;
 	}
 }
 

--- a/packages/widgets/index.android.ts
+++ b/packages/widgets/index.android.ts
@@ -1,0 +1,276 @@
+import { Utils } from '@nativescript/core';
+
+class WidgetManager {
+	//@ts-ignore
+	private _manager: org.nativescript.widgets.AppWidgetManager;
+
+	get native() {
+		return this._manager;
+	}
+
+	static fromNative(manager: org.nativescript.widgets.AppWidgetManager) {
+		const ret = new WidgetManager();
+		ret._manager = manager;
+		return ret;
+	}
+}
+
+class AndroidWidgetManager {
+	private _widgetManager: android.appwidget.AppWidgetManager;
+
+	constructor(nativeManager: android.appwidget.AppWidgetManager) {
+		this._widgetManager = nativeManager;
+	}
+
+	get native() {
+		return this._widgetManager;
+	}
+
+	static fromNative(nativeManager: android.appwidget.AppWidgetManager) {
+		return new AndroidWidgetManager(nativeManager);
+	}
+}
+
+interface IWidgetListener {
+	onEnabled?: (provider: string) => void;
+	onUpdate?: (event: { provider: string; appWidgetIds: number[]; manager: WidgetManager; widgetManager: AndroidWidgetManager }) => void;
+	onUpdateAsync?: (event: { provider: string; appWidgetIds: number[]; manager: WidgetManager; widgetManager: AndroidWidgetManager }) => void;
+	onDeleted?: (event: { provider: string; appWidgetIds: number[] }) => void;
+	onDisabled?: (provider: string) => void;
+}
+
+export class AndroidRemoteViews {
+	private _remoteViews: android.widget.RemoteViews;
+
+	constructor(remoteViews: android.widget.RemoteViews) {
+		this._remoteViews = remoteViews;
+	}
+
+	get native() {
+		return this._remoteViews;
+	}
+}
+
+export class RemoteViews {
+	protected _remoteViews: org.nativescript.widgets.RemoteViews;
+
+	constructor(remoteViews: org.nativescript.widgets.RemoteViews) {
+		this._remoteViews = remoteViews;
+	}
+
+	get native() {
+		return this._remoteViews;
+	}
+
+	toAndroidRemoteViews(packageName?: string): AndroidRemoteViews {
+		return new AndroidRemoteViews(this._remoteViews.build(packageName ?? Utils.android.getApplicationContext().getPackageName()));
+	}
+}
+
+export class AdapterViewFlipper extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.AdapterViewFlipper(id ?? null));
+	}
+}
+
+export class Button extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.Button(id ?? null));
+	}
+}
+
+export class Chronometer extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.Chronometer(id ?? null));
+	}
+}
+
+export class FrameLayout extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.FrameLayout(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.FrameLayout;
+	}
+
+	addView(view: RemoteViews) {
+		this.native.addView(view.native);
+	}
+
+	removeView(view: RemoteViews) {
+		this.native.removeView(view.native);
+	}
+}
+
+export class GridLayout extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.GridLayout(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.GridLayout;
+	}
+
+	addView(view: RemoteViews) {
+		this.native.addView(view.native);
+	}
+
+	removeView(view: RemoteViews) {
+		this.native.removeView(view.native);
+	}
+}
+
+export class GridView extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.GridView(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.GridView;
+	}
+
+	addView(view: RemoteViews) {
+		this.native.addView(view.native);
+	}
+
+	removeView(view: RemoteViews) {
+		this.native.removeView(view.native);
+	}
+}
+
+export class ImageButton extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.ImageButton(id ?? null));
+	}
+}
+
+export class ImageView extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.ImageView(id ?? null));
+	}
+}
+
+export class LinearLayout extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.LinearLayout(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.LinearLayout;
+	}
+
+	addView(view: RemoteViews) {
+		this.native.addView(view.native);
+	}
+
+	removeView(view: RemoteViews) {
+		this.native.removeView(view.native);
+	}
+}
+
+export class ListView extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.ListView(id ?? null));
+	}
+}
+
+export class ProgressBar extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.ProgressBar(id ?? null));
+	}
+}
+
+export class RelativeLayout extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.RelativeLayout(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.RelativeLayout;
+	}
+
+	addView(view: RemoteViews) {
+		this.native.addView(view.native);
+	}
+
+	removeView(view: RemoteViews) {
+		this.native.removeView(view.native);
+	}
+}
+
+export class StackView extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.StackView(id ?? null));
+	}
+
+	get native() {
+		return this._remoteViews as org.nativescript.widgets.RemoteViews.StackView;
+	}
+
+	addView(view: RemoteViews) {
+		this.native.addView(view.native);
+	}
+
+	removeView(view: RemoteViews) {
+		this.native.removeView(view.native);
+	}
+}
+
+export class TextView extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.TextView(id ?? null));
+	}
+}
+
+export class TextClock extends RemoteViews {
+	constructor(id?: string) {
+		super(new org.nativescript.widgets.RemoteViews.TextClock(id ?? null));
+	}
+}
+
+export function registerWidgetListener(provider: string, listener: IWidgetListener) {
+	const opts: {
+		onEnabled: (provider: string) => void;
+		onUpdateAsync?: (context: any, provider: string, appWidgetIds: any, manager: any, widgetManager: any) => void;
+		onUpdate: (context: any, provider: string, appWidgetIds: any, manager: any, widgetManager: any) => void;
+		onDeleted: (provider: string, appWidgetIds: any) => void;
+		onDisabled: (provider: string) => void;
+	} = {
+		onEnabled(provider: string) {
+			if (listener.onEnabled) {
+				listener.onEnabled(provider);
+			}
+		},
+		onUpdateAsync(context: any, provider: string, appWidgetIds: any, manager: any, widgetManager: any) {
+			if (listener.onUpdateAsync) {
+				listener.onUpdateAsync({ provider, appWidgetIds: Utils.dataDeserialize(appWidgetIds), manager: WidgetManager.fromNative(manager), widgetManager: AndroidWidgetManager.fromNative(widgetManager) });
+			}
+		},
+		onUpdate(context: any, provider: string, appWidgetIds: any, manager: any, widgetManager: any) {
+			if (listener.onUpdate) {
+				listener.onUpdate({ provider, appWidgetIds: Utils.dataDeserialize(appWidgetIds), manager: WidgetManager.fromNative(manager), widgetManager: AndroidWidgetManager.fromNative(widgetManager) });
+			}
+		},
+		onDeleted(provider: string, appWidgetIds: any) {
+			if (listener.onDeleted) {
+				listener.onDeleted({ provider, appWidgetIds: Utils.dataDeserialize(appWidgetIds) });
+			}
+		},
+		onDisabled(provider: string) {
+			if (listener.onDisabled) {
+				listener.onDisabled(provider);
+			}
+		},
+	};
+
+	if (!listener.onUpdateAsync && opts.onUpdateAsync) {
+		delete opts.onUpdateAsync;
+	}
+
+	org.nativescript.widgets.AppWidgetManager.INSTANCE.register(provider, new org.nativescript.widgets.AppWidgetManager.WidgetListener(opts));
+}
+
+export function unregisterWidgetListener(provider: string) {
+	org.nativescript.widgets.AppWidgetManager.INSTANCE.unregister(provider);
+}

--- a/packages/widgets/index.d.ts
+++ b/packages/widgets/index.d.ts
@@ -1,0 +1,139 @@
+export declare class AndroidRemoteViews {
+	private _remoteViews;
+	constructor(remoteViews: android.widget.RemoteViews);
+	get native(): android.widget.RemoteViews;
+}
+
+export declare class RemoteViews {
+	protected _remoteViews: org.nativescript.widgets.RemoteViews;
+	constructor(remoteViews: org.nativescript.widgets.RemoteViews);
+	get native(): org.nativescript.widgets.RemoteViews;
+	setOnClickPendingIntent(intent: android.app.PendingIntent): this;
+	setBackgroundColor(value: number): this;
+	setBoolean(method: string, value: boolean): this;
+	setByte(method: string, value: number): this;
+	setShort(method: string, value: number): this;
+	setInt(method: string, value: number): this;
+	setLong(method: string, value: number): this;
+	setFloat(method: string, value: number): this;
+	setString(method: string, value: string): this;
+	setSize(width: number, widthUnit: number, height: number, heightUnit: number): this;
+	setWidth(value: number, unit: number): this;
+	setHeight(value: number, unit: number): this;
+	setVisibility(visibility: number): this;
+	findViewById(id: string): RemoteViews | null;
+	resolveRemoteResources(): this;
+	toAndroidRemoteViews(packageName?: string): AndroidRemoteViews;
+}
+
+export declare class AdapterViewFlipper extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.AdapterViewFlipper;
+}
+
+export declare class Button extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.Button;
+	setText(value: string): this;
+	setTextColor(value: number): this;
+}
+
+export declare class Chronometer extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.Chronometer;
+}
+
+export declare class FrameLayout extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.FrameLayout;
+	addView(view: RemoteViews): void;
+	removeView(view: RemoteViews): void;
+}
+
+export declare class GridLayout extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.GridLayout;
+	addView(view: RemoteViews): void;
+	removeView(view: RemoteViews): void;
+}
+
+export declare class GridView extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.GridView;
+	addView(view: RemoteViews): void;
+	removeView(view: RemoteViews): void;
+}
+
+export declare class ImageButton extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.ImageButton;
+	setImageUrl(url: string): this;
+	setImageResource(value: number): this;
+	setImageURI(value: android.net.Uri): this;
+	setImageBitmap(value: android.graphics.Bitmap): this;
+}
+
+export declare class ImageView extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.ImageView;
+	setImageUrl(url: string): this;
+	setImageResource(value: number): this;
+	setImageURI(value: android.net.Uri): this;
+	setImageBitmap(value: android.graphics.Bitmap): this;
+}
+
+export declare class LinearLayout extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.LinearLayout;
+	addView(view: RemoteViews): void;
+	removeView(view: RemoteViews): void;
+}
+
+export declare class ListView extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.ListView;
+}
+
+export declare class ProgressBar extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.ProgressBar;
+}
+
+export declare class RelativeLayout extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.RelativeLayout;
+	addView(view: RemoteViews): void;
+	removeView(view: RemoteViews): void;
+}
+
+export declare class StackView extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.StackView;
+	addView(view: RemoteViews): void;
+	removeView(view: RemoteViews): void;
+}
+
+export declare class TextView extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.TextView;
+	setText(value: string): this;
+	setTextColor(value: number): this;
+}
+
+export declare class TextClock extends RemoteViews {
+	constructor(id?: string);
+	get native(): org.nativescript.widgets.RemoteViews.TextClock;
+	setText(value: string): this;
+	setTextColor(value: number): this;
+}
+
+interface IWidgetListener {
+	onEnabled?: (provider: string) => void;
+	onUpdate?: (event: { provider: string; appWidgetIds: number[]; manager: { native: org.nativescript.widgets.AppWidgetManager }; widgetManager: { native: android.appwidget.AppWidgetManager } }) => void;
+	onUpdateAsync?: (event: { provider: string; appWidgetIds: number[]; manager: { native: org.nativescript.widgets.AppWidgetManager }; widgetManager: { native: android.appwidget.AppWidgetManager } }) => void;
+	onDeleted?: (event: { provider: string; appWidgetIds: number[] }) => void;
+	onDisabled?: (provider: string) => void;
+}
+
+export declare function registerWidgetListener(provider: string, listener: IWidgetListener): void;
+export declare function unregisterWidgetListener(provider: string): void;

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@nativescript/widgets",
+	"version": "1.0.0",
+	"description": "Build and drive Android home-screen widgets (RemoteViews) from NativeScript.",
+	"main": "index",
+	"types": "index.d.ts",
+	"nativescript": {
+		"platforms": {
+			"ios": "6.0.0",
+			"android": "6.0.0"
+		}
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/NativeScript/plugins.git"
+	},
+	"keywords": [
+		"NativeScript",
+		"JavaScript",
+		"TypeScript",
+		"iOS",
+		"Android"
+	],
+	"author": {
+		"name": "NativeScript",
+		"email": "oss@nativescript.org"
+	},
+	"bugs": {
+		"url": "https://github.com/NativeScript/plugins/issues"
+	},
+	"license": "Apache-2.0",
+	"homepage": "https://github.com/NativeScript/plugins",
+	"readmeFilename": "README.md",
+	"bootstrapper": "@nativescript/plugin-seed"
+}

--- a/packages/widgets/platforms/android/java/org/nativescript/widgets/AppWidgetManager.kt
+++ b/packages/widgets/platforms/android/java/org/nativescript/widgets/AppWidgetManager.kt
@@ -1,0 +1,109 @@
+package org.nativescript.widgets
+
+import android.content.Context
+import android.os.Bundle
+import java.util.concurrent.ConcurrentHashMap
+
+object AppWidgetManager {
+
+	interface WidgetListener {
+		fun onEnabled(provider: String) {}
+
+		fun onUpdate(
+			context: Context,
+			provider: String,
+			appWidgetIds: IntArray,
+			manager: RemoteViewsManager,
+			widgetManager: android.appwidget.AppWidgetManager?
+		) {
+		}
+
+
+		fun onUpdateAsync(
+			context: Context,
+			provider: String,
+			appWidgetIds: IntArray,
+			manager: RemoteViewsManager,
+			widgetManager: android.appwidget.AppWidgetManager?
+		) {
+		}
+
+		fun onDisabled(provider: String) {}
+		fun onDeleted(provider: String, appWidgetIds: IntArray) {}
+		fun onOptionsChanged(
+			context: Context,
+			provider: String,
+			appWidgetId: Int,
+			newOptions: Bundle,
+			manager: RemoteViewsManager,
+			widgetManager: android.appwidget.AppWidgetManager?
+		) {
+		}
+	}
+
+	private val listeners = ConcurrentHashMap<String, WidgetListener>()
+	private val managers = ConcurrentHashMap<String, RemoteViewsManager>()
+
+	fun register(providerClass: String, listener: WidgetListener) {
+		listeners[providerClass] = listener
+	}
+
+	fun unregister(providerClass: String) {
+		listeners.remove(providerClass)
+		managers.remove(providerClass)
+	}
+
+	fun getManager(providerClass: String): RemoteViewsManager {
+		return managers.getOrPut(providerClass) { RemoteViewsManager() }
+	}
+
+	internal fun notifyUpdate(
+		context: Context,
+		provider: String,
+		appWidgetIds: IntArray,
+		manager: RemoteViewsManager,
+		widgetManager: android.appwidget.AppWidgetManager?
+	) {
+		listeners[provider]?.onUpdate(context, provider, appWidgetIds, manager, widgetManager)
+	}
+
+	internal fun notifyUpdateAsync(
+		context: Context,
+		provider: String,
+		appWidgetIds: IntArray,
+		manager: RemoteViewsManager,
+		widgetManager: android.appwidget.AppWidgetManager?
+	) {
+		listeners[provider]?.onUpdateAsync(context, provider, appWidgetIds, manager, widgetManager)
+	}
+
+	internal fun notifyEnabled(provider: String) {
+		listeners[provider]?.onEnabled(provider)
+	}
+
+	internal fun notifyDisabled(provider: String) {
+		listeners[provider]?.onDisabled(provider)
+	}
+
+	internal fun notifyDeleted(provider: String, appWidgetIds: IntArray) {
+		listeners[provider]?.onDeleted(provider, appWidgetIds)
+	}
+
+	internal fun notifyOptionsChanged(
+		context: Context,
+		provider: String,
+		appWidgetId: Int,
+		newOptions: Bundle,
+		manager: RemoteViewsManager,
+		widgetManager: android.appwidget.AppWidgetManager?,
+	) {
+		listeners[provider]?.onOptionsChanged(
+			context,
+			provider,
+			appWidgetId,
+			newOptions,
+			manager,
+			widgetManager
+		)
+	}
+}

--- a/packages/widgets/platforms/android/java/org/nativescript/widgets/AppWidgetProvider.kt
+++ b/packages/widgets/platforms/android/java/org/nativescript/widgets/AppWidgetProvider.kt
@@ -1,0 +1,105 @@
+package org.nativescript.widgets
+
+import android.content.ComponentName
+import android.content.Context
+import android.os.Bundle
+import androidx.work.WorkerParameters
+
+open class AppWidgetProvider : android.appwidget.AppWidgetProvider() {
+	private val providerName = this::class.java.name
+	open val interval = 900000L
+
+	internal class WidgetWorker(
+		context: Context,
+		params: WorkerParameters
+	) : AppWidgetWorker(context, params) {
+		override fun doWork(): Result {
+			val appWidgetManager = android.appwidget.AppWidgetManager.getInstance(applicationContext)
+			val component = ComponentName(
+				applicationContext, this.provider
+			)
+			val ids = appWidgetManager.getAppWidgetIds(component)
+			if (ids.isEmpty()) {
+				cancelPeriodic(
+					applicationContext,
+					this.provider
+				)
+				return Result.success()
+			}
+
+			val manager = AppWidgetManager.getManager(this.provider)
+			AppWidgetManager.notifyUpdateAsync(
+				applicationContext,
+				this.provider,
+				ids,
+				manager,
+				appWidgetManager
+			)
+
+			return Result.success()
+		}
+	}
+
+	override fun onEnabled(context: Context) {
+		super.onEnabled(context)
+		AppWidgetManager.notifyEnabled(providerName)
+		AppWidgetWorker.enqueuePeriodic<WidgetWorker>(context, providerName, intArrayOf(), interval)
+	}
+
+	override fun onUpdate(
+		context: Context?,
+		appWidgetManager: android.appwidget.AppWidgetManager?,
+		appWidgetIds: IntArray?
+	) {
+		val context = context ?: return
+		val ids = appWidgetIds ?: return
+		val manager = AppWidgetManager.getManager(providerName)
+		AppWidgetManager.notifyUpdate(
+			context,
+			providerName,
+			ids,
+			manager,
+			appWidgetManager
+		)
+		AppWidgetWorker.enqueueImmediate<WidgetWorker>(
+			context, providerName, ids
+		)
+	}
+
+	override fun onDeleted(context: Context?, appWidgetIds: IntArray?) {
+		super.onDeleted(context, appWidgetIds)
+		appWidgetIds?.let {
+			AppWidgetManager.notifyDeleted(providerName, it)
+		}
+	}
+
+	override fun onDisabled(context: Context) {
+		super.onDisabled(context)
+		AppWidgetManager.notifyDisabled(providerName)
+		AppWidgetWorker.cancelPeriodic(
+			context, providerName
+		)
+	}
+
+
+	override fun onAppWidgetOptionsChanged(
+		context: Context?,
+		appWidgetManager: android.appwidget.AppWidgetManager?,
+		appWidgetId: Int,
+		newOptions: Bundle?
+	) {
+		super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
+		val ctx = context ?: return
+		newOptions?.let {
+			val manager = AppWidgetManager.getManager(providerName)
+			AppWidgetManager.notifyOptionsChanged(
+				ctx,
+				providerName,
+				appWidgetId,
+				it,
+				manager,
+				appWidgetManager
+			)
+		}
+	}
+}

--- a/packages/widgets/platforms/android/java/org/nativescript/widgets/AppWidgetWorker.kt
+++ b/packages/widgets/platforms/android/java/org/nativescript/widgets/AppWidgetWorker.kt
@@ -1,0 +1,161 @@
+package org.nativescript.widgets
+
+import android.content.Context
+import android.os.SystemClock
+import androidx.work.Data
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+abstract class AppWidgetWorker(
+	context: Context,
+	params: WorkerParameters
+) : Worker(context, params) {
+
+	val widgetIds: IntArray
+		get() = inputData.getIntArray(KEY_WIDGET_IDS) ?: intArrayOf()
+
+	val provider: String
+		get() = inputData.getString(KEY_PROVIDER) ?: ""
+
+	companion object {
+		const val KEY_WIDGET_IDS = "widget_ids"
+		const val KEY_PROVIDER = "provider"
+
+		private val lastEnqueuedAt = ConcurrentHashMap<String, Long>()
+		private const val MIN_INTERVAL_MS = 3000L
+
+		@JvmStatic
+		fun buildData(provider: String, widgetIds: IntArray): Data {
+			return Data.Builder()
+				.putString(KEY_PROVIDER, provider)
+				.putIntArray(KEY_WIDGET_IDS, widgetIds)
+				.build()
+		}
+
+		@JvmStatic
+		fun <T : AppWidgetWorker> enqueue(
+			context: Context,
+			workerClass: Class<T>,
+			provider: String,
+			widgetIds: IntArray
+		) {
+			val workName = "widget_update_${provider}_once"
+			val now = SystemClock.elapsedRealtime()
+			val last = lastEnqueuedAt[workName]
+			if (last != null && now - last < MIN_INTERVAL_MS) return
+			lastEnqueuedAt[workName] = now
+
+			val request = OneTimeWorkRequest.Builder(workerClass)
+				.setInputData(buildData(provider, widgetIds))
+				.build()
+			WorkManager.getInstance(context)
+				.enqueueUniqueWork(
+					workName,
+					ExistingWorkPolicy.REPLACE,
+					request
+				)
+		}
+
+		inline fun <reified T : AppWidgetWorker> enqueue(
+			context: Context,
+			provider: String,
+			widgetIds: IntArray
+		) = enqueue(context, T::class.java, provider, widgetIds)
+
+		@JvmStatic
+		@JvmOverloads
+		fun <T : AppWidgetWorker> enqueuePeriodic(
+			context: Context,
+			workerClass: Class<T>,
+			provider: String,
+			widgetIds: IntArray,
+			repeatIntervalMilliSeconds: Long = 900000, // 15 mins min time allowed
+			uniqueWorkName: String = "widget_update_$provider"
+		) {
+			val request = PeriodicWorkRequest.Builder(
+				workerClass,
+				repeatIntervalMilliSeconds, TimeUnit.MILLISECONDS
+			)
+				.setInputData(buildData(provider, widgetIds))
+				.build()
+			WorkManager.getInstance(context)
+				.enqueueUniquePeriodicWork(
+					uniqueWorkName,
+					ExistingPeriodicWorkPolicy.UPDATE,
+					request
+				)
+		}
+
+		inline fun <reified T : AppWidgetWorker> enqueuePeriodic(
+			context: Context,
+			provider: String,
+			widgetIds: IntArray,
+			repeatIntervalMilliSeconds: Long = 900000,
+			uniqueWorkName: String = "widget_update_$provider"
+		) = enqueuePeriodic(
+			context,
+			T::class.java,
+			provider,
+			widgetIds,
+			repeatIntervalMilliSeconds,
+			uniqueWorkName
+		)
+
+		@JvmStatic
+		@JvmOverloads
+		fun cancelPeriodic(
+			context: Context,
+			provider: String,
+			uniqueWorkName: String = "widget_update_$provider"
+		) {
+			WorkManager.getInstance(context).cancelUniqueWork(uniqueWorkName)
+		}
+
+
+		@JvmStatic
+		inline fun <reified T : AppWidgetWorker> enqueueImmediate(
+			context: Context,
+			provider: String,
+			widgetIds: IntArray,
+		) {
+			val request = OneTimeWorkRequest.Builder(T::class.java)
+				.setInputData(buildData(provider, widgetIds))
+				.build()
+			WorkManager.getInstance(context).enqueueUniqueWork(
+				"widget_${provider}_immediate",
+				ExistingWorkPolicy.KEEP,
+				request
+			)
+		}
+
+		@JvmStatic
+		fun isScheduled(context: Context, provider: String): Boolean {
+			val statuses = WorkManager.getInstance(context)
+				.getWorkInfosForUniqueWork("widget_update_$provider")
+				.get()
+			return statuses.any { it.state == WorkInfo.State.ENQUEUED || it.state == WorkInfo.State.RUNNING }
+		}
+	}
+
+	fun updateWidgets(rv: android.widget.RemoteViews?) {
+		rv ?: return
+		val mgr = android.appwidget.AppWidgetManager.getInstance(applicationContext)
+		for (id in widgetIds) {
+			mgr.updateAppWidget(id, rv)
+		}
+	}
+
+	fun updateWidget(widgetId: Int, rv: android.widget.RemoteViews?) {
+		rv ?: return
+		val mgr = android.appwidget.AppWidgetManager.getInstance(applicationContext)
+		mgr.updateAppWidget(widgetId, rv)
+	}
+}

--- a/packages/widgets/platforms/android/java/org/nativescript/widgets/RemoteViews.kt
+++ b/packages/widgets/platforms/android/java/org/nativescript/widgets/RemoteViews.kt
@@ -1,0 +1,489 @@
+package org.nativescript.widgets
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import java.net.URL
+import java.util.concurrent.atomic.AtomicLong
+
+open class RemoteViews(val layout: Layout, val id: String = generateId()) {
+
+	companion object {
+		private val counter = AtomicLong(0)
+		fun generateId(): String = "ns_rv_${counter.incrementAndGet()}"
+	}
+
+	internal val commands = mutableMapOf<String, Command>()
+	internal var stableId: Int? = null
+	internal var manager: RemoteViewsManager? = null
+
+	sealed class Command {
+		abstract fun applyTo(rv: android.widget.RemoteViews, targetId: Int)
+
+		open fun applyToWithContext(rv: android.widget.RemoteViews, targetId: Int, context: Context) {}
+
+		data class SetText(val value: String) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setTextViewText(targetId, value)
+			}
+		}
+
+		data class SetTextColor(val value: Int) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setTextColor(targetId, value)
+			}
+		}
+
+		data class SetImageResource(val resId: Int) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setImageViewResource(targetId, resId)
+			}
+		}
+
+		data class SetVisibility(val visibility: Int) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setViewVisibility(targetId, visibility)
+			}
+		}
+
+		data class SetByte(val method: String, val value: Byte) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setByte(targetId, method, value)
+			}
+		}
+
+		data class SetShort(val method: String, val value: Short) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setShort(targetId, method, value)
+			}
+		}
+
+		data class SetInt(val method: String, val value: Int) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setInt(targetId, method, value)
+			}
+		}
+
+		data class SetLong(val method: String, val value: Long) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setLong(targetId, method, value)
+			}
+		}
+
+		data class SetFloat(val method: String, val value: Float) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setFloat(targetId, method, value)
+			}
+		}
+
+		data class SetBoolean(val method: String, val value: Boolean) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setBoolean(targetId, method, value)
+			}
+		}
+
+		data class SetString(val method: String, val value: String) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setString(targetId, method, value)
+			}
+		}
+
+		data class SetBackgroundColor(val value: Int) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setInt(targetId, "setBackgroundColor", value)
+			}
+		}
+
+
+		data class SetImageURI(val value: Uri?) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setImageViewUri(targetId, value)
+			}
+		}
+
+		data class SetImageBitmap(val value: Bitmap) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setImageViewBitmap(targetId, value)
+			}
+		}
+
+		data class SetImageUrl(val url: String) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				// no-op: must be resolved via resolveRemoteResources() before build
+			}
+
+			fun resolve(): SetImageBitmap? {
+				return try {
+					val bitmap = URL(url).openStream().use { BitmapFactory.decodeStream(it) }
+					bitmap?.let { SetImageBitmap(it) }
+				} catch (e: Exception) {
+					null
+				}
+			}
+		}
+
+		data class SetOnClickPendingIntent(val intent: PendingIntent) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				rv.setOnClickPendingIntent(
+					targetId, intent
+				)
+			}
+
+			override fun applyToWithContext(
+				rv: android.widget.RemoteViews,
+				targetId: Int,
+				context: Context
+			) {
+			}
+		}
+
+		data class SetWidth(val value: Float, val unit: Int) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+					rv.setViewLayoutWidth(targetId, value, unit)
+				}
+			}
+		}
+
+		data class SetHeight(val value: Float, val unit: Int) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+					rv.setViewLayoutHeight(targetId, value, unit)
+				}
+			}
+		}
+
+		data class SetSize(
+			val width: Float,
+			val widthUnit: Int,
+			val height: Float,
+			val heightUnit: Int
+		) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+					rv.setViewLayoutWidth(targetId, width, widthUnit)
+					rv.setViewLayoutHeight(targetId, height, heightUnit)
+				}
+			}
+		}
+
+		data class SetWidthDimen(val value: Float, val resource: String, val packageName: String?) :
+			Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {}
+
+			@SuppressLint("DiscouragedApi")
+			override fun applyToWithContext(
+				rv: android.widget.RemoteViews,
+				targetId: Int,
+				context: Context
+			) {
+				val res = context.resources.getIdentifier(
+					resource, "dimen", packageName ?: context.packageName
+				)
+				if (res > 0) {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+						rv.setViewLayoutWidthDimen(
+							targetId,
+							res
+						)
+					}
+				}
+			}
+		}
+
+		data class SetHeightDimen(val value: Float, val resource: String, val packageName: String?) :
+			Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {}
+
+			@SuppressLint("DiscouragedApi")
+			override fun applyToWithContext(
+				rv: android.widget.RemoteViews,
+				targetId: Int,
+				context: Context
+			) {
+				val res = context.resources.getIdentifier(
+					resource, "dimen", packageName ?: context.packageName
+				)
+				if (res > 0) {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+						rv.setViewLayoutHeightDimen(
+							targetId,
+							res
+						)
+					}
+				}
+			}
+		}
+
+		data class SetSizeDimen(
+			val width: Float,
+			val widthResource: String,
+			val widthPackageName: String?,
+			val height: Float,
+			val heightResource: String,
+			val heightPackageName: String?
+		) : Command() {
+			override fun applyTo(rv: android.widget.RemoteViews, targetId: Int) {}
+
+			@SuppressLint("DiscouragedApi")
+			override fun applyToWithContext(
+				rv: android.widget.RemoteViews,
+				targetId: Int,
+				context: Context
+			) {
+				val widthRes = context.resources.getIdentifier(
+					widthResource, "dimen", widthPackageName ?: context.packageName
+				)
+				if (widthRes > 0) {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+						rv.setViewLayoutWidthDimen(
+							targetId,
+							widthRes
+						)
+					}
+				}
+
+
+				val heightRes = context.resources.getIdentifier(
+					heightResource, "dimen", heightPackageName ?: context.packageName
+				)
+				if (heightRes > 0) {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+						rv.setViewLayoutHeightDimen(
+							targetId,
+							heightRes
+						)
+					}
+				}
+			}
+		}
+	}
+
+	fun resolveRemoteResources() {
+		ensureManager()
+		manager?.resolveRemoteResources()
+	}
+
+	fun build(packageName: String): android.widget.RemoteViews? {
+		ensureManager()
+		return manager?.build(id, packageName)
+	}
+
+	private fun ensureManager() {
+		if (manager == null) {
+			val mgr = RemoteViewsManager()
+			mgr.add(this)
+		}
+	}
+
+	internal fun buildSelf(packageName: String): android.widget.RemoteViews {
+		stableId = R.id.ns_remote_view_root
+		val rv = android.widget.RemoteViews(packageName, toLayoutId())
+		commands.values.forEach { cmd -> cmd.applyTo(rv, stableId!!) }
+		return rv
+	}
+
+	enum class Layout {
+		AdapterViewFlipper,
+		Button,
+		Chronometer,
+		FrameLayout,
+		GridLayout,
+		GridView,
+		ImageButton,
+		ImageView,
+		LinearLayout,
+		ListView,
+		ProgressBar,
+		RelativeLayout,
+		StackView,
+		TextView,
+		ViewFlipper,
+		TextClock
+	}
+
+	fun setBackgroundColor(value: Int): RemoteViews {
+		commands["setBackgroundColor"] = Command.SetBackgroundColor(value)
+		return this
+	}
+
+	fun setVisibility(visibility: Int): RemoteViews {
+		commands["setVisibility"] = Command.SetVisibility(visibility)
+		return this
+	}
+
+	fun setString(method: String, value: String): RemoteViews {
+		commands["setString:$method"] = Command.SetString(method, value)
+		return this
+	}
+
+	fun setByte(method: String, value: Byte): RemoteViews {
+		commands["setByte:$method"] = Command.SetByte(method, value)
+		return this
+	}
+
+	fun setInt(method: String, value: Int): RemoteViews {
+		commands["setInt:$method"] = Command.SetInt(method, value)
+		return this
+	}
+
+	fun setShort(method: String, value: Short): RemoteViews {
+		commands["setShort:$method"] = Command.SetShort(method, value)
+		return this
+	}
+
+	fun setLong(method: String, value: Long): RemoteViews {
+		commands["setLong:$method"] = Command.SetLong(method, value)
+		return this
+	}
+
+	fun setFloat(method: String, value: Float): RemoteViews {
+		commands["setFloat:$method"] = Command.SetFloat(method, value)
+		return this
+	}
+
+	fun setBoolean(method: String, value: Boolean): RemoteViews {
+		commands["setBoolean:$method"] = Command.SetBoolean(method, value)
+		return this
+	}
+
+	fun setWidth(value: Float, unit: Int): RemoteViews {
+		commands["setWidth"] = Command.SetWidth(value, unit)
+		return this
+	}
+
+	fun setHeight(value: Float, unit: Int): RemoteViews {
+		commands["setHeight"] = Command.SetHeight(value, unit)
+		return this
+	}
+
+	fun setSize(width: Float, widthUnit: Int, height: Float, heightUnit: Int): RemoteViews {
+		commands["setSize"] = Command.SetSize(width, widthUnit, height, heightUnit)
+		return this
+	}
+
+	fun setOnClickPendingIntent(intent: PendingIntent): RemoteViews {
+		commands["setOnClickPendingIntent"] = Command.SetOnClickPendingIntent(intent)
+		return this
+	}
+
+	fun toLayoutId(): Int {
+		return when (layout) {
+			Layout.AdapterViewFlipper -> R.layout.ns_remote_views_adapter_view_flipper
+			Layout.Button -> R.layout.ns_remote_views_button
+			Layout.Chronometer -> R.layout.ns_remote_views_chronometer
+			Layout.FrameLayout -> R.layout.ns_remote_views_frame_layout
+			Layout.GridLayout -> R.layout.ns_remote_views_grid_layout
+			Layout.GridView -> R.layout.ns_remote_views_grid_view
+			Layout.ImageButton -> R.layout.ns_remote_views_image_button
+			Layout.ImageView -> R.layout.ns_remote_views_image_view
+			Layout.LinearLayout -> R.layout.ns_remote_views_linear_layout
+			Layout.ListView -> R.layout.ns_remote_views_list_view
+			Layout.ProgressBar -> R.layout.ns_remote_views_progress_bar
+			Layout.RelativeLayout -> R.layout.ns_remote_views_relative_layout
+			Layout.StackView -> R.layout.ns_remote_views_stack_view
+			Layout.TextView -> R.layout.ns_remote_views_text_view
+			Layout.ViewFlipper -> R.layout.ns_remote_views_view_flipper
+			Layout.TextClock -> R.layout.ns_remote_views_text_clock
+		}
+	}
+
+	fun findViewById(id: String): RemoteViews? {
+		return manager?.findViewById(this.id, id)
+	}
+
+	fun getCommands(): MutableMap<String, Command> {
+		return commands
+	}
+
+	class AdapterViewFlipper(id: String = generateId()) : RemoteViews(Layout.AdapterViewFlipper, id)
+
+	class Button(id: String = generateId()) : RemoteViews(Layout.Button, id), TextLike
+
+	class Chronometer(id: String = generateId()) : RemoteViews(Layout.Chronometer, id)
+
+	class FrameLayout(id: String = generateId()) : RemoteViews(Layout.FrameLayout, id), ViewGroupLike
+
+	class GridLayout(id: String = generateId()) : RemoteViews(Layout.GridLayout, id), ViewGroupLike
+
+	class GridView(id: String = generateId()) : RemoteViews(Layout.GridView, id), ViewGroupLike
+
+	class ImageButton(id: String = generateId()) : RemoteViews(Layout.ImageButton, id), ImageLike
+
+	class ImageView(id: String = generateId()) : RemoteViews(Layout.ImageView, id), ImageLike
+
+	class LinearLayout(id: String = generateId()) : RemoteViews(Layout.LinearLayout, id),
+		ViewGroupLike
+
+	class ListView(id: String = generateId()) : RemoteViews(Layout.ListView, id)
+
+	class ProgressBar(id: String = generateId()) : RemoteViews(Layout.ProgressBar, id)
+
+	class RelativeLayout(id: String = generateId()) : RemoteViews(Layout.RelativeLayout, id),
+		ViewGroupLike
+
+	class StackView(id: String = generateId()) : RemoteViews(Layout.StackView, id), ViewGroupLike
+
+	class TextView(id: String = generateId()) : RemoteViews(Layout.TextView, id), TextLike
+
+	class ViewFlipper(id: String = generateId()) : RemoteViews(Layout.ViewFlipper, id), ViewGroupLike
+
+	class TextClock(id: String = generateId()) : RemoteViews(Layout.TextClock, id), TextLike
+
+	interface TextLike {
+		fun getCommands(): MutableMap<String, Command>
+
+		fun setText(value: String): TextLike {
+			getCommands()["setText"] = Command.SetText(value)
+			return this
+		}
+
+		fun setTextColor(value: Int): TextLike {
+			getCommands()["setTextColor"] = Command.SetTextColor(value)
+			return this
+		}
+	}
+
+	interface ViewGroupLike {
+		fun addView(child: RemoteViews): ViewGroupLike {
+			val self = this as RemoteViews
+			self.ensureManager()
+			self.manager?.add(child, self.id)
+			return this
+		}
+
+		fun removeView(child: RemoteViews): ViewGroupLike {
+			val self = this as RemoteViews
+			child.id.let { self.manager?.remove(it) }
+			return this
+		}
+	}
+
+	interface ImageLike {
+		fun getCommands(): MutableMap<String, Command>
+
+		fun setImageResource(value: Int): ImageLike {
+			getCommands()["setImageResource"] = Command.SetImageResource(value)
+			return this
+		}
+
+		fun setImageURI(value: Uri?): ImageLike {
+			getCommands()["setImageURI"] = Command.SetImageURI(value)
+			return this
+		}
+
+		fun setImageBitmap(value: Bitmap): ImageLike {
+			getCommands()["setImageBitmap"] = Command.SetImageBitmap(value)
+			return this
+		}
+
+		fun setImageUrl(url: String): ImageLike {
+			getCommands()["setImageUrl"] = Command.SetImageUrl(url)
+			return this
+		}
+	}
+}

--- a/packages/widgets/platforms/android/java/org/nativescript/widgets/RemoteViewsManager.kt
+++ b/packages/widgets/platforms/android/java/org/nativescript/widgets/RemoteViewsManager.kt
@@ -1,0 +1,108 @@
+package org.nativescript.widgets
+
+class RemoteViewsManager {
+	private val nodes = mutableMapOf<String, RemoteViews>()
+	private val parents = mutableMapOf<String, String?>()
+	private val children = mutableMapOf<String, MutableList<String>>()
+
+	fun add(node: RemoteViews, parentId: String? = null) {
+		val id = node.id
+		node.manager = this
+		nodes[id] = node
+		parents[id] = parentId
+		children[id] = mutableListOf()
+
+		// register as child of parent
+		parentId?.let { children[it]?.add(id) }
+	}
+
+	fun remove(id: String) {
+		// detach from parent
+		parents[id]?.let { parentId ->
+			children[parentId]?.remove(id)
+		}
+		// reparent children to null or could reparent to grandparent
+		children[id]?.forEach { childId ->
+			parents[childId] = null
+		}
+		nodes[id]?.manager = null
+		nodes.remove(id)
+		parents.remove(id)
+		children.remove(id)
+	}
+
+	fun reparent(id: String, newParentId: String?) {
+		// detach from old parent
+		parents[id]?.let { oldParentId ->
+			children[oldParentId]?.remove(id)
+		}
+		// attach to new parent
+		parents[id] = newParentId
+		newParentId?.let { children[it]?.add(id) }
+	}
+
+	fun getById(id: String): RemoteViews? = nodes[id]
+
+	fun findViewById(parentId: String, targetId: String): RemoteViews? {
+		if (parentId == targetId) return nodes[parentId]
+		children[parentId]?.forEach { childId ->
+			if (childId == targetId) return nodes[childId]
+			val found = findViewById(childId, targetId)
+			if (found != null) return found
+		}
+		return null
+	}
+
+	fun getChildren(id: String): List<RemoteViews> {
+		return children[id]?.mapNotNull { nodes[it] } ?: emptyList()
+	}
+
+	fun getParent(id: String): RemoteViews? {
+		return parents[id]?.let { nodes[it] }
+	}
+
+	fun resolveRemoteResources() {
+		for (node in nodes.values) {
+			val iterator = node.commands.entries.iterator()
+			val resolved = mutableMapOf<String, RemoteViews.Command>()
+			while (iterator.hasNext()) {
+				val entry = iterator.next()
+				val cmd = entry.value
+				if (cmd is RemoteViews.Command.SetImageUrl) {
+					val bitmap = cmd.resolve()
+					if (bitmap != null) {
+						resolved[entry.key] = bitmap
+					} else {
+						iterator.remove()
+					}
+				}
+			}
+			node.commands.putAll(resolved)
+		}
+	}
+
+	fun build(packageName: String): android.widget.RemoteViews? {
+		val rootId = parents.entries.firstOrNull { it.value == null }?.key ?: return null
+		val root = nodes[rootId] ?: return null
+		return buildNode(rootId, packageName, root)
+	}
+
+	fun build(rootId: String, packageName: String): android.widget.RemoteViews? {
+		val root = nodes[rootId] ?: return null
+		return buildNode(rootId, packageName, root)
+	}
+
+	private fun buildNode(
+		id: String,
+		packageName: String,
+		node: RemoteViews
+	): android.widget.RemoteViews {
+		val rv = node.buildSelf(packageName)
+		children[id]?.forEach { childId ->
+			val childNode = nodes[childId] ?: return@forEach
+			val childRv = buildNode(childId, packageName, childNode)
+			rv.addView(node.stableId!!, childRv)
+		}
+		return rv
+	}
+}

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_adapter_view_flipper.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_adapter_view_flipper.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AdapterViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+
+</AdapterViewFlipper>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_button.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_button.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="wrap_content"
+	android:layout_height="wrap_content" />

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_chronometer.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_chronometer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Chronometer xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</Chronometer>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_frame_layout.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_frame_layout.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</FrameLayout>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_grid_layout.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_grid_layout.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</GridLayout>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_grid_view.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_grid_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GridView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</GridView>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_image_button.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_image_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageButton xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</ImageButton>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_image_view.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_image_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</ImageView>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_linear_layout.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_linear_layout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:orientation="vertical"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</LinearLayout>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_list_view.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_list_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ListView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</ListView>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_progress_bar.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_progress_bar.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProgressBar xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</ProgressBar>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_relative_layout.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_relative_layout.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</RelativeLayout>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_stack_view.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_stack_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StackView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</StackView>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_text_clock.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_text_clock.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextClock xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</TextClock>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_text_view.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_text_view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="wrap_content"
+	android:layout_height="wrap_content">
+
+</TextView>

--- a/packages/widgets/platforms/android/res/layout/ns_remote_views_view_flipper.xml
+++ b/packages/widgets/platforms/android/res/layout/ns_remote_views_view_flipper.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@id/ns_remote_view_root"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+</ViewFlipper>

--- a/packages/widgets/platforms/android/res/values/ids.xml
+++ b/packages/widgets/platforms/android/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<item name="ns_remote_view_root" type="id" />
+</resources>

--- a/packages/widgets/project.json
+++ b/packages/widgets/project.json
@@ -1,0 +1,65 @@
+{
+	"name": "widgets",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/widgets",
+	"targets": {
+		"build": {
+			"executor": "@nx/js:tsc",
+			"options": {
+				"outputPath": "dist/packages/widgets",
+				"tsConfig": "packages/widgets/tsconfig.json",
+				"packageJson": "packages/widgets/package.json",
+				"main": "packages/widgets/index.d.ts",
+				"assets": [
+					"packages/widgets/*.md",
+					"packages/widgets/index.d.ts",
+					"LICENSE",
+					{
+						"glob": "**/*",
+						"input": "packages/widgets/platforms/",
+						"output": "./platforms/"
+					}
+				],
+				"dependsOn": [
+					{
+						"target": "build.all",
+						"projects": "dependencies"
+					}
+				]
+			}
+		},
+		"build.all": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["node tools/scripts/build-finish.ts widgets"],
+				"parallel": false
+			},
+			"outputs": ["{workspaceRoot}/dist/packages/widgets"],
+			"dependsOn": [
+				{
+					"target": "build.all",
+					"projects": "dependencies"
+				},
+				{
+					"target": "build",
+					"projects": "self"
+				}
+			]
+		},
+		"focus": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx g @nativescript/plugin-tools:focus-packages widgets"],
+				"parallel": false
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:eslint",
+			"options": {
+				"lintFilePatterns": ["packages/widgets/**/*.ts"]
+			}
+		}
+	},
+	"tags": []
+}

--- a/packages/widgets/references.d.ts
+++ b/packages/widgets/references.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../references.d.ts" />

--- a/packages/widgets/tsconfig.json
+++ b/packages/widgets/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"rootDir": "."
+	},
+	"exclude": ["**/*.spec.ts", "**/*.test.ts", "angular"],
+	"include": ["**/*.ts", "references.d.ts"]
+}

--- a/packages/widgets/typings/org.nativescript.widgets.d.ts
+++ b/packages/widgets/typings/org.nativescript.widgets.d.ts
@@ -1,0 +1,722 @@
+declare module org {
+	export module nativescript {
+		export module widgets {
+			export class AppWidgetManager {
+				public static class: java.lang.Class<org.nativescript.widgets.AppWidgetManager>;
+				public static INSTANCE: org.nativescript.widgets.AppWidgetManager;
+				public notifyEnabled$widgets_release(provider: string): void;
+				public notifyDeleted$widgets_release(provider: string, appWidgetIds: androidNative.Array<number>): void;
+				public notifyOptionsChanged$widgets_release(context: globalAndroid.content.Context, provider: string, appWidgetId: number, newOptions: globalAndroid.os.Bundle, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+				public notifyUpdateAsync$widgets_release(context: globalAndroid.content.Context, provider: string, appWidgetIds: androidNative.Array<number>, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+				public getManager(provider: string): org.nativescript.widgets.RemoteViewsManager;
+				public register(providerClass: string, listener: org.nativescript.widgets.AppWidgetManager.WidgetListener): void;
+				public unregister(providerClass: string): void;
+				public notifyUpdate$widgets_release(context: globalAndroid.content.Context, provider: string, appWidgetIds: androidNative.Array<number>, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+				public notifyDisabled$widgets_release(provider: string): void;
+			}
+			export module AppWidgetManager {
+				export class WidgetListener {
+					public static class: java.lang.Class<org.nativescript.widgets.AppWidgetManager.WidgetListener>;
+					/**
+					 * Constructs a new instance of the org.nativescript.widgets.AppWidgetManager$WidgetListener interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+					 */
+					public constructor(implementation: {
+						onEnabled?(provider: string): void;
+						onUpdate?(context: globalAndroid.content.Context, provider: string, appWidgetIds: androidNative.Array<number>, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+						onUpdateAsync?(context: globalAndroid.content.Context, provider: string, appWidgetIds: androidNative.Array<number>, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+						onDisabled?(provider: string): void;
+						onDeleted?(provider: string, appWidgetIds: androidNative.Array<number>): void;
+						onOptionsChanged?(context: globalAndroid.content.Context, provider: string, appWidgetId: number, newOptions: globalAndroid.os.Bundle, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+					});
+					public constructor();
+					public onEnabled(provider: string): void;
+					public onUpdate(context: globalAndroid.content.Context, provider: string, appWidgetIds: androidNative.Array<number>, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+					public onDisabled(provider: string): void;
+					public onDeleted(provider: string, appWidgetIds: androidNative.Array<number>): void;
+					public onUpdateAsync(context: globalAndroid.content.Context, provider: string, appWidgetIds: androidNative.Array<number>, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+					public onOptionsChanged(context: globalAndroid.content.Context, provider: string, appWidgetId: number, newOptions: globalAndroid.os.Bundle, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+				}
+				export module WidgetListener {
+					export class DefaultImpls {
+						public static class: java.lang.Class<org.nativescript.widgets.AppWidgetManager.WidgetListener.DefaultImpls>;
+						/** @deprecated */
+						public static onOptionsChanged($this: org.nativescript.widgets.AppWidgetManager.WidgetListener, context: globalAndroid.content.Context, provider: string, appWidgetId: number, newOptions: globalAndroid.os.Bundle, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+						/** @deprecated */
+						public static onUpdateAsync($this: org.nativescript.widgets.AppWidgetManager.WidgetListener, context: globalAndroid.content.Context, provider: string, appWidgetIds: androidNative.Array<number>, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+						/** @deprecated */
+						public static onEnabled($this: org.nativescript.widgets.AppWidgetManager.WidgetListener, provider: string): void;
+						/** @deprecated */
+						public static onDisabled($this: org.nativescript.widgets.AppWidgetManager.WidgetListener, provider: string): void;
+						/** @deprecated */
+						public static onUpdate($this: org.nativescript.widgets.AppWidgetManager.WidgetListener, context: globalAndroid.content.Context, provider: string, appWidgetIds: androidNative.Array<number>, manager: org.nativescript.widgets.RemoteViewsManager, widgetManager: globalAndroid.appwidget.AppWidgetManager): void;
+						/** @deprecated */
+						public static onDeleted($this: org.nativescript.widgets.AppWidgetManager.WidgetListener, provider: string, appWidgetIds: androidNative.Array<number>): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module org {
+	export module nativescript {
+		export module widgets {
+			export class AppWidgetProvider {
+				public static class: java.lang.Class<org.nativescript.widgets.AppWidgetProvider>;
+				public onDisabled(context: globalAndroid.content.Context): void;
+				public onEnabled($this$iv: globalAndroid.content.Context): void;
+				public onUpdate(request$iv: globalAndroid.content.Context, this_$iv: globalAndroid.appwidget.AppWidgetManager, context$iv: androidNative.Array<number>): void;
+				public onDeleted(it: globalAndroid.content.Context, this_: androidNative.Array<number>): void;
+				public onAppWidgetOptionsChanged(manager: globalAndroid.content.Context, it: globalAndroid.appwidget.AppWidgetManager, ctx: number, this_: globalAndroid.os.Bundle): void;
+				public constructor();
+			}
+			export module AppWidgetProvider {
+				export class WidgetWorker extends org.nativescript.widgets.AppWidgetWorker {
+					public static class: java.lang.Class<org.nativescript.widgets.AppWidgetProvider.WidgetWorker>;
+					public constructor(context: globalAndroid.content.Context, params: androidx.work.WorkerParameters);
+					public doWork(): androidx.work.ListenableWorker.Result;
+				}
+			}
+		}
+	}
+}
+
+declare module org {
+	export module nativescript {
+		export module widgets {
+			export abstract class AppWidgetWorker {
+				public static class: java.lang.Class<org.nativescript.widgets.AppWidgetWorker>;
+				public static KEY_WIDGET_IDS: string = 'widget_ids';
+				public static KEY_PROVIDER: string = 'provider';
+				public getWidgetIds(): androidNative.Array<number>;
+				public static enqueue(context: globalAndroid.content.Context, workerClass: java.lang.Class<any>, provider: string, widgetIds: androidNative.Array<number>): void;
+				public updateWidget(this_: number, widgetId: globalAndroid.widget.RemoteViews): void;
+				public static enqueuePeriodic(context: globalAndroid.content.Context, workerClass: java.lang.Class<any>, provider: string, widgetIds: androidNative.Array<number>, repeatIntervalMinutes: number): void;
+				public updateWidgets(mgr: globalAndroid.widget.RemoteViews): void;
+				public getProvider(): string;
+				public static cancelPeriodic(context: globalAndroid.content.Context, provider: string): void;
+				public static buildData(provider: string, widgetIds: androidNative.Array<number>): androidx.work.Data;
+				public static enqueuePeriodic(context: globalAndroid.content.Context, workerClass: java.lang.Class<any>, provider: string, widgetIds: androidNative.Array<number>): void;
+				public static cancelPeriodic(context: globalAndroid.content.Context, provider: string, uniqueWorkName: string): void;
+				public constructor(context: globalAndroid.content.Context, params: androidx.work.WorkerParameters);
+				public static enqueuePeriodic(context: globalAndroid.content.Context, workerClass: java.lang.Class<any>, provider: string, widgetIds: androidNative.Array<number>, repeatIntervalMinutes: number, uniqueWorkName: string): void;
+				public static isScheduled(context: globalAndroid.content.Context, provider: string): boolean;
+			}
+			export module AppWidgetWorker {
+				export class Companion {
+					public static class: java.lang.Class<org.nativescript.widgets.AppWidgetWorker.Companion>;
+					public enqueuePeriodic(this_: globalAndroid.content.Context, context: java.lang.Class<any>, workerClass: string, provider: androidNative.Array<number>, widgetIds: number, repeatIntervalMinutes: string): void;
+					public buildData(provider: string, widgetIds: androidNative.Array<number>): androidx.work.Data;
+					public isScheduled(it: globalAndroid.content.Context, element$iv: string): boolean;
+					public enqueuePeriodic(context: globalAndroid.content.Context, workerClass: java.lang.Class<any>, provider: string, widgetIds: androidNative.Array<number>, repeatIntervalMinutes: number): void;
+					public cancelPeriodic(context: globalAndroid.content.Context, provider: string): void;
+					public cancelPeriodic(context: globalAndroid.content.Context, provider: string, uniqueWorkName: string): void;
+					public enqueue(now: globalAndroid.content.Context, last: java.lang.Class<any>, request: string, this_: androidNative.Array<number>): void;
+					public enqueuePeriodic(context: globalAndroid.content.Context, workerClass: java.lang.Class<any>, provider: string, widgetIds: androidNative.Array<number>): void;
+				}
+			}
+		}
+	}
+}
+
+declare module org {
+	export module nativescript {
+		export module widgets {
+			export class RemoteViews {
+				public static class: java.lang.Class<org.nativescript.widgets.RemoteViews>;
+				public getId(): string;
+				public setShort(method: string, value: number): org.nativescript.widgets.RemoteViews;
+				public setBoolean(method: string, value: boolean): org.nativescript.widgets.RemoteViews;
+				public setLong(method: string, value: number): org.nativescript.widgets.RemoteViews;
+				public setInt(method: string, value: number): org.nativescript.widgets.RemoteViews;
+				public setOnClickPendingIntent(intent: globalAndroid.app.PendingIntent): org.nativescript.widgets.RemoteViews;
+				public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+				public getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+				public setBackgroundColor(value: number): org.nativescript.widgets.RemoteViews;
+				public setString(method: string, value: string): org.nativescript.widgets.RemoteViews;
+				public setFloat(method: string, value: number): org.nativescript.widgets.RemoteViews;
+				public setByte(method: string, value: number): org.nativescript.widgets.RemoteViews;
+				public setSize(width: number, widthUnit: number, height: number, heightUnit: number): org.nativescript.widgets.RemoteViews;
+				public findViewById(id: string): org.nativescript.widgets.RemoteViews;
+				public build(packageName: string): globalAndroid.widget.RemoteViews;
+				public getLayout(): org.nativescript.widgets.RemoteViews.Layout;
+				public setHeight(value: number, unit: number): org.nativescript.widgets.RemoteViews;
+				public resolveRemoteResources(): void;
+				public toLayoutId(): number;
+				public setVisibility(visibility: number): org.nativescript.widgets.RemoteViews;
+				public setWidth(value: number, unit: number): org.nativescript.widgets.RemoteViews;
+			}
+			export module RemoteViews {
+				export class AdapterViewFlipper extends org.nativescript.widgets.RemoteViews {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.AdapterViewFlipper>;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public constructor(id: string | null);
+				}
+				export class Button extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.TextLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Button>;
+					public getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+					public constructor();
+					public setText(value: string): org.nativescript.widgets.RemoteViews.TextLike;
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public constructor(id: string | null);
+					public setTextColor(value: number): org.nativescript.widgets.RemoteViews.TextLike;
+				}
+				export class Chronometer extends org.nativescript.widgets.RemoteViews {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Chronometer>;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public constructor(id: string | null);
+				}
+				export abstract class Command {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command>;
+					public applyToWithContext(rv: globalAndroid.widget.RemoteViews, targetId: number, context: globalAndroid.content.Context): void;
+					public applyTo(param0: globalAndroid.widget.RemoteViews, param1: number): void;
+				}
+				export module Command {
+					export class SetBackgroundColor extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetBackgroundColor>;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public constructor(value: number);
+						public component1(): number;
+						public copy(value: number): org.nativescript.widgets.RemoteViews.Command.SetBackgroundColor;
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetBoolean extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetBoolean>;
+						public equals(other: any): boolean;
+						public copy(method: string, value: boolean): org.nativescript.widgets.RemoteViews.Command.SetBoolean;
+						public component2(): boolean;
+						public constructor(method: string, value: boolean);
+						public getValue(): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public component1(): string;
+						public hashCode(): number;
+						public getMethod(): string;
+						public toString(): string;
+					}
+					export class SetByte extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetByte>;
+						public component2(): number;
+						public equals(other: any): boolean;
+						public copy(method: string, value: number): org.nativescript.widgets.RemoteViews.Command.SetByte;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public component1(): string;
+						public hashCode(): number;
+						public getMethod(): string;
+						public constructor(method: string, value: number);
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetFloat extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetFloat>;
+						public component2(): number;
+						public copy(method: string, value: number): org.nativescript.widgets.RemoteViews.Command.SetFloat;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public component1(): string;
+						public hashCode(): number;
+						public getMethod(): string;
+						public constructor(method: string, value: number);
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetHeight extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetHeight>;
+						public constructor(value: number, unit: number);
+						public component2(): number;
+						public equals(other: any): boolean;
+						public copy(value: number, unit: number): org.nativescript.widgets.RemoteViews.Command.SetHeight;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public getUnit(): number;
+						public hashCode(): number;
+						public component1(): number;
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetHeightDimen extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetHeightDimen>;
+						public component3(): string;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public toString(): string;
+						public constructor(value: number, resource: string, packageName: string);
+						public getPackageName(): string;
+						public component2(): string;
+						public copy(value: number, resource: string, packageName: string): org.nativescript.widgets.RemoteViews.Command.SetHeightDimen;
+						public applyToWithContext(this_: globalAndroid.widget.RemoteViews, rv: number, targetId: globalAndroid.content.Context): void;
+						public component1(): number;
+						public getResource(): string;
+						public getValue(): number;
+					}
+					export class SetImageBitmap extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetImageBitmap>;
+						public constructor(value: globalAndroid.graphics.Bitmap);
+						public equals(other: any): boolean;
+						public getValue(): globalAndroid.graphics.Bitmap;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public copy(value: globalAndroid.graphics.Bitmap): org.nativescript.widgets.RemoteViews.Command.SetImageBitmap;
+						public hashCode(): number;
+						public component1(): globalAndroid.graphics.Bitmap;
+						public toString(): string;
+					}
+					export class SetImageResource extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetImageResource>;
+						public equals(other: any): boolean;
+						public constructor(resId: number);
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public getResId(): number;
+						public component1(): number;
+						public copy(resId: number): org.nativescript.widgets.RemoteViews.Command.SetImageResource;
+						public toString(): string;
+					}
+					export class SetImageURI extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetImageURI>;
+						public copy(value: globalAndroid.net.Uri): org.nativescript.widgets.RemoteViews.Command.SetImageURI;
+						public equals(other: any): boolean;
+						public constructor(value: globalAndroid.net.Uri);
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public getValue(): globalAndroid.net.Uri;
+						public component1(): globalAndroid.net.Uri;
+						public toString(): string;
+					}
+					export class SetImageUrl extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetImageUrl>;
+						public equals(other: any): boolean;
+						public copy(url: string): org.nativescript.widgets.RemoteViews.Command.SetImageUrl;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public resolve(): org.nativescript.widgets.RemoteViews.Command.SetImageBitmap;
+						public component1(): string;
+						public hashCode(): number;
+						public constructor(url: string);
+						public getUrl(): string;
+						public toString(): string;
+					}
+					export class SetInt extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetInt>;
+						public component2(): number;
+						public copy(method: string, value: number): org.nativescript.widgets.RemoteViews.Command.SetInt;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public component1(): string;
+						public hashCode(): number;
+						public getMethod(): string;
+						public constructor(method: string, value: number);
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetLong extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetLong>;
+						public component2(): number;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public component1(): string;
+						public hashCode(): number;
+						public getMethod(): string;
+						public copy(method: string, value: number): org.nativescript.widgets.RemoteViews.Command.SetLong;
+						public constructor(method: string, value: number);
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetOnClickPendingIntent extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetOnClickPendingIntent>;
+						public equals(other: any): boolean;
+						public applyToWithContext(rv: globalAndroid.widget.RemoteViews, targetId: number, context: globalAndroid.content.Context): void;
+						public constructor(intent: globalAndroid.app.PendingIntent);
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public getIntent(): globalAndroid.app.PendingIntent;
+						public copy(intent: globalAndroid.app.PendingIntent): org.nativescript.widgets.RemoteViews.Command.SetOnClickPendingIntent;
+						public toString(): string;
+						public component1(): globalAndroid.app.PendingIntent;
+					}
+					export class SetShort extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetShort>;
+						public component2(): number;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public component1(): string;
+						public copy(method: string, value: number): org.nativescript.widgets.RemoteViews.Command.SetShort;
+						public hashCode(): number;
+						public getMethod(): string;
+						public constructor(method: string, value: number);
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetSize extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetSize>;
+						public getWidthUnit(): number;
+						public equals(other: any): boolean;
+						public getHeightUnit(): number;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public copy(width: number, widthUnit: number, height: number, heightUnit: number): org.nativescript.widgets.RemoteViews.Command.SetSize;
+						public getHeight(): number;
+						public component4(): number;
+						public toString(): string;
+						public component2(): number;
+						public constructor(width: number, widthUnit: number, height: number, heightUnit: number);
+						public getWidth(): number;
+						public component1(): number;
+						public component3(): number;
+					}
+					export class SetSizeDimen extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetSizeDimen>;
+						public component3(): string;
+						public equals(other: any): boolean;
+						public component5(): string;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public copy(width: number, widthResource: string, widthPackageName: string, height: number, heightResource: string, heightPackageName: string): org.nativescript.widgets.RemoteViews.Command.SetSizeDimen;
+						public getHeight(): number;
+						public applyToWithContext(heightRes: globalAndroid.widget.RemoteViews, this_: number, rv: globalAndroid.content.Context): void;
+						public getWidthResource(): string;
+						public component4(): number;
+						public toString(): string;
+						public getHeightResource(): string;
+						public constructor(width: number, widthResource: string, widthPackageName: string, height: number, heightResource: string, heightPackageName: string);
+						public getWidth(): number;
+						public component2(): string;
+						public getWidthPackageName(): string;
+						public component6(): string;
+						public getHeightPackageName(): string;
+						public component1(): number;
+					}
+					export class SetString extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetString>;
+						public equals(other: any): boolean;
+						public constructor(method: string, value: string);
+						public component2(): string;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public component1(): string;
+						public hashCode(): number;
+						public getMethod(): string;
+						public copy(method: string, value: string): org.nativescript.widgets.RemoteViews.Command.SetString;
+						public getValue(): string;
+						public toString(): string;
+					}
+					export class SetText extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetText>;
+						public equals(other: any): boolean;
+						public copy(value: string): org.nativescript.widgets.RemoteViews.Command.SetText;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public component1(): string;
+						public hashCode(): number;
+						public constructor(value: string);
+						public getValue(): string;
+						public toString(): string;
+					}
+					export class SetTextColor extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetTextColor>;
+						public copy(value: number): org.nativescript.widgets.RemoteViews.Command.SetTextColor;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public constructor(value: number);
+						public component1(): number;
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetVisibility extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetVisibility>;
+						public equals(other: any): boolean;
+						public getVisibility(): number;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public constructor(visibility: number);
+						public component1(): number;
+						public copy(visibility: number): org.nativescript.widgets.RemoteViews.Command.SetVisibility;
+						public toString(): string;
+					}
+					export class SetWidth extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetWidth>;
+						public constructor(value: number, unit: number);
+						public component2(): number;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public getUnit(): number;
+						public copy(value: number, unit: number): org.nativescript.widgets.RemoteViews.Command.SetWidth;
+						public hashCode(): number;
+						public component1(): number;
+						public toString(): string;
+						public getValue(): number;
+					}
+					export class SetWidthDimen extends org.nativescript.widgets.RemoteViews.Command {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Command.SetWidthDimen>;
+						public component3(): string;
+						public equals(other: any): boolean;
+						public applyTo(rv: globalAndroid.widget.RemoteViews, targetId: number): void;
+						public hashCode(): number;
+						public copy(value: number, resource: string, packageName: string): org.nativescript.widgets.RemoteViews.Command.SetWidthDimen;
+						public toString(): string;
+						public constructor(value: number, resource: string, packageName: string);
+						public getPackageName(): string;
+						public component2(): string;
+						public applyToWithContext(this_: globalAndroid.widget.RemoteViews, rv: number, targetId: globalAndroid.content.Context): void;
+						public component1(): number;
+						public getResource(): string;
+						public getValue(): number;
+					}
+				}
+				export class Companion {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Companion>;
+					public generateId(): string;
+				}
+				export class FrameLayout extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ViewGroupLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.FrameLayout>;
+					public addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public addView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public removeView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor(id: string | null);
+				}
+				export class GridLayout extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ViewGroupLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.GridLayout>;
+					public addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public addView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public removeView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor(id: string | null);
+				}
+				export class GridView extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ViewGroupLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.GridView>;
+					public addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public addView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public removeView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor(id: string | null);
+				}
+				export class ImageButton extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ImageLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ImageButton>;
+					public getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public setImageUrl(url: string): org.nativescript.widgets.RemoteViews.ImageLike;
+					public setImageResource(value: number): org.nativescript.widgets.RemoteViews.ImageLike;
+					public constructor(id: string | null);
+					public setImageURI(value: globalAndroid.net.Uri): org.nativescript.widgets.RemoteViews.ImageLike;
+					public setImageBitmap(value: globalAndroid.graphics.Bitmap): org.nativescript.widgets.RemoteViews.ImageLike;
+				}
+				export class ImageLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ImageLike>;
+					/**
+					 * Constructs a new instance of the org.nativescript.widgets.RemoteViews$ImageLike interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+					 */
+					public constructor(implementation: {
+						getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+						setImageResource(value: number): org.nativescript.widgets.RemoteViews.ImageLike;
+						setImageURI(value: globalAndroid.net.Uri): org.nativescript.widgets.RemoteViews.ImageLike;
+						setImageBitmap(value: globalAndroid.graphics.Bitmap): org.nativescript.widgets.RemoteViews.ImageLike;
+						setImageUrl(url: string): org.nativescript.widgets.RemoteViews.ImageLike;
+						access$setImageResource$jd($this: org.nativescript.widgets.RemoteViews.ImageLike, value: number): org.nativescript.widgets.RemoteViews.ImageLike;
+						access$setImageURI$jd($this: org.nativescript.widgets.RemoteViews.ImageLike, value: globalAndroid.net.Uri): org.nativescript.widgets.RemoteViews.ImageLike;
+						access$setImageBitmap$jd($this: org.nativescript.widgets.RemoteViews.ImageLike, value: globalAndroid.graphics.Bitmap): org.nativescript.widgets.RemoteViews.ImageLike;
+						access$setImageUrl$jd($this: org.nativescript.widgets.RemoteViews.ImageLike, url: string): org.nativescript.widgets.RemoteViews.ImageLike;
+					});
+					public constructor();
+					public getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+					public setImageUrl(url: string): org.nativescript.widgets.RemoteViews.ImageLike;
+					public setImageResource(value: number): org.nativescript.widgets.RemoteViews.ImageLike;
+					public setImageURI(value: globalAndroid.net.Uri): org.nativescript.widgets.RemoteViews.ImageLike;
+					public setImageBitmap(value: globalAndroid.graphics.Bitmap): org.nativescript.widgets.RemoteViews.ImageLike;
+				}
+				export module ImageLike {
+					export class DefaultImpls {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ImageLike.DefaultImpls>;
+						/** @deprecated */
+						public static setImageBitmap($this: org.nativescript.widgets.RemoteViews.ImageLike, value: globalAndroid.graphics.Bitmap): org.nativescript.widgets.RemoteViews.ImageLike;
+						/** @deprecated */
+						public static setImageUrl($this: org.nativescript.widgets.RemoteViews.ImageLike, url: string): org.nativescript.widgets.RemoteViews.ImageLike;
+						/** @deprecated */
+						public static setImageResource($this: org.nativescript.widgets.RemoteViews.ImageLike, value: number): org.nativescript.widgets.RemoteViews.ImageLike;
+						/** @deprecated */
+						public static setImageURI($this: org.nativescript.widgets.RemoteViews.ImageLike, value: globalAndroid.net.Uri): org.nativescript.widgets.RemoteViews.ImageLike;
+					}
+				}
+				export class ImageView extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ImageLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ImageView>;
+					public getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public setImageUrl(url: string): org.nativescript.widgets.RemoteViews.ImageLike;
+					public setImageResource(value: number): org.nativescript.widgets.RemoteViews.ImageLike;
+					public constructor(id: string | null);
+					public setImageURI(value: globalAndroid.net.Uri): org.nativescript.widgets.RemoteViews.ImageLike;
+					public setImageBitmap(value: globalAndroid.graphics.Bitmap): org.nativescript.widgets.RemoteViews.ImageLike;
+				}
+				export class Layout {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.Layout>;
+					public static AdapterViewFlipper: org.nativescript.widgets.RemoteViews.Layout;
+					public static Button: org.nativescript.widgets.RemoteViews.Layout;
+					public static Chronometer: org.nativescript.widgets.RemoteViews.Layout;
+					public static FrameLayout: org.nativescript.widgets.RemoteViews.Layout;
+					public static GridLayout: org.nativescript.widgets.RemoteViews.Layout;
+					public static GridView: org.nativescript.widgets.RemoteViews.Layout;
+					public static ImageButton: org.nativescript.widgets.RemoteViews.Layout;
+					public static ImageView: org.nativescript.widgets.RemoteViews.Layout;
+					public static LinearLayout: org.nativescript.widgets.RemoteViews.Layout;
+					public static ListView: org.nativescript.widgets.RemoteViews.Layout;
+					public static ProgressBar: org.nativescript.widgets.RemoteViews.Layout;
+					public static RelativeLayout: org.nativescript.widgets.RemoteViews.Layout;
+					public static StackView: org.nativescript.widgets.RemoteViews.Layout;
+					public static TextView: org.nativescript.widgets.RemoteViews.Layout;
+					public static ViewFlipper: org.nativescript.widgets.RemoteViews.Layout;
+					public static TextClock: org.nativescript.widgets.RemoteViews.Layout;
+					public static getEntries(): any;
+					public static valueOf(value: string): org.nativescript.widgets.RemoteViews.Layout;
+					public static values(): androidNative.Array<org.nativescript.widgets.RemoteViews.Layout>;
+				}
+				export class LinearLayout extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ViewGroupLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.LinearLayout>;
+					public addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public addView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public removeView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor(id: string | null);
+				}
+				export class ListView extends org.nativescript.widgets.RemoteViews {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ListView>;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public constructor(id: string | null);
+				}
+				export class ProgressBar extends org.nativescript.widgets.RemoteViews {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ProgressBar>;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public constructor(id: string | null);
+				}
+				export class RelativeLayout extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ViewGroupLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.RelativeLayout>;
+					public addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public addView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public removeView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor(id: string | null);
+				}
+				export class StackView extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ViewGroupLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.StackView>;
+					public addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public addView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public removeView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor(id: string | null);
+				}
+				export class TextClock extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.TextLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.TextClock>;
+					public getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+					public constructor();
+					public setText(value: string): org.nativescript.widgets.RemoteViews.TextLike;
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public constructor(id: string | null);
+					public setTextColor(value: number): org.nativescript.widgets.RemoteViews.TextLike;
+				}
+				export class TextLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.TextLike>;
+					/**
+					 * Constructs a new instance of the org.nativescript.widgets.RemoteViews$TextLike interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+					 */
+					public constructor(implementation: { getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>; setText(value: string): org.nativescript.widgets.RemoteViews.TextLike; setTextColor(value: number): org.nativescript.widgets.RemoteViews.TextLike; access$setText$jd($this: org.nativescript.widgets.RemoteViews.TextLike, value: string): org.nativescript.widgets.RemoteViews.TextLike; access$setTextColor$jd($this: org.nativescript.widgets.RemoteViews.TextLike, value: number): org.nativescript.widgets.RemoteViews.TextLike });
+					public constructor();
+					public getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+					public setText(value: string): org.nativescript.widgets.RemoteViews.TextLike;
+					public setTextColor(value: number): org.nativescript.widgets.RemoteViews.TextLike;
+				}
+				export module TextLike {
+					export class DefaultImpls {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.TextLike.DefaultImpls>;
+						/** @deprecated */
+						public static setText($this: org.nativescript.widgets.RemoteViews.TextLike, value: string): org.nativescript.widgets.RemoteViews.TextLike;
+						/** @deprecated */
+						public static setTextColor($this: org.nativescript.widgets.RemoteViews.TextLike, value: number): org.nativescript.widgets.RemoteViews.TextLike;
+					}
+				}
+				export class TextView extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.TextLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.TextView>;
+					public getCommands(): java.util.Map<string, org.nativescript.widgets.RemoteViews.Command>;
+					public constructor();
+					public setText(value: string): org.nativescript.widgets.RemoteViews.TextLike;
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public constructor(id: string | null);
+					public setTextColor(value: number): org.nativescript.widgets.RemoteViews.TextLike;
+				}
+				export class ViewFlipper extends org.nativescript.widgets.RemoteViews implements org.nativescript.widgets.RemoteViews.ViewGroupLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ViewFlipper>;
+					public addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public addView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public removeView(child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor();
+					public constructor(layout: org.nativescript.widgets.RemoteViews.Layout, id: string);
+					public removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public constructor(id: string | null);
+				}
+				export class ViewGroupLike {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ViewGroupLike>;
+					/**
+					 * Constructs a new instance of the org.nativescript.widgets.RemoteViews$ViewGroupLike interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+					 */
+					public constructor(implementation: {
+						addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+						removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+						access$addView$jd($this: org.nativescript.widgets.RemoteViews.ViewGroupLike, child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+						access$removeView$jd($this: org.nativescript.widgets.RemoteViews.ViewGroupLike, child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					});
+					public constructor();
+					public addView(this_: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					public removeView(it: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+				}
+				export module ViewGroupLike {
+					export class DefaultImpls {
+						public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.ViewGroupLike.DefaultImpls>;
+						/** @deprecated */
+						public static addView($this: org.nativescript.widgets.RemoteViews.ViewGroupLike, child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+						/** @deprecated */
+						public static removeView($this: org.nativescript.widgets.RemoteViews.ViewGroupLike, child: org.nativescript.widgets.RemoteViews): org.nativescript.widgets.RemoteViews.ViewGroupLike;
+					}
+				}
+				export class WhenMappings {
+					public static class: java.lang.Class<org.nativescript.widgets.RemoteViews.WhenMappings>;
+				}
+			}
+		}
+	}
+}
+
+declare module org {
+	export module nativescript {
+		export module widgets {
+			export class RemoteViewsManager {
+				public static class: java.lang.Class<org.nativescript.widgets.RemoteViewsManager>;
+				public reparent(oldParentId: string, newParentId: string): void;
+				public build(it: string): globalAndroid.widget.RemoteViews;
+				public build(this_: string, rootId: string): globalAndroid.widget.RemoteViews;
+				public findViewById(found: string, childId: string): org.nativescript.widgets.RemoteViews;
+				public resolveRemoteResources(): void;
+				public remove(parentId: string): void;
+				public add(it: org.nativescript.widgets.RemoteViews, id: string): void;
+				public getById(id: string): org.nativescript.widgets.RemoteViews;
+				public getChildren(it: string): java.util.List<org.nativescript.widgets.RemoteViews>;
+				public constructor();
+				public getParent(it: string): org.nativescript.widgets.RemoteViews;
+			}
+		}
+	}
+}

--- a/tools/demo/index.ts
+++ b/tools/demo/index.ts
@@ -36,4 +36,5 @@ export * from './shared-notification-delegate';
 export * from './social-share';
 export * from './theme-switcher';
 export * from './twitter';
+export * from './widgets';
 export * from './zip';

--- a/tools/demo/widgets/index.ts
+++ b/tools/demo/widgets/index.ts
@@ -1,0 +1,8 @@
+import { DemoSharedBase } from '../utils';
+import {} from '@nativescript/widgets';
+
+export class DemoSharedWidgets extends DemoSharedBase {
+	testIt() {
+		console.log('test widgets!');
+	}
+}

--- a/tools/workspace-scripts.js
+++ b/tools/workspace-scripts.js
@@ -316,6 +316,13 @@ module.exports = {
 					description: '@nativescript/input-accessory: Build',
 				},
 			},
+			// @nativescript/widgets
+			widgets: {
+				build: {
+					script: 'nx run widgets:build.all',
+					description: '@nativescript/widgets: Build',
+				},
+			},
 			'build-all': {
 				script: 'nx run-many --target=build.all --all',
 				description: 'Build all packages',
@@ -481,6 +488,10 @@ module.exports = {
 			'input-accessory': {
 				script: 'nx run input-accessory:focus',
 				description: 'Focus on @nativescript/input-accessory',
+			},
+			widgets: {
+				script: 'nx run widgets:focus',
+				description: 'Focus on @nativescript/widgets',
 			},
 			reset: {
 				script: 'nx g @nativescript/plugin-tools:focus-packages',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -66,7 +66,8 @@
 			"@nativescript/theme-switcher": ["packages/theme-switcher/index.ts"],
 			"@nativescript/twitter": ["packages/twitter/index.d.ts"],
 			"@nativescript/zip": ["packages/zip/index.d.ts"],
-			"@nativescript/input-accessory": ["packages/input-accessory/index.d.ts"]
+			"@nativescript/input-accessory": ["packages/input-accessory/index.d.ts"],
+			"@nativescript/widgets": ["packages/widgets/index.d.ts"]
 		}
 	},
 	"exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
Adds `@nativescript/widgets` package, which provides support for building and managing Android home-screen widgets (RemoteViews) in NativeScript. The package includes both TypeScript and native Android (Kotlin) implementations.