### PR TITLE
fix(secure-storage): make the ios simulator NSUserDefaults fallback opt-in

### DIFF
--- a/packages/secure-storage/README.md
+++ b/packages/secure-storage/README.md
@@ -113,9 +113,15 @@ const secureStorage = new SecureStorage(kSecAttrAccessibleWhenUnlockedThisDevice
 
 ## iOS Simulator
 
-Currently this plugin defaults to using `NSUserDefaults` on **iOS Simulators**. You can change this behaviour by providing `disableFallbackToUserDefaults` to the constructor of `SecureStorage`. This then uses the keychain instead of `NSUserDefaults` on simulators.
+The plugin uses the keychain on **iOS Simulators** just like it does on device, so no configuration is needed.
 
-If you're running into issues similar to [issue_10](https://github.com/EddyVerbruggen/nativescript-secure-storage/issues/10), consider using the default behaviour again.
+An opt-in fallback to `NSUserDefaults` on the simulator is still available for toolchains old enough that `SecItemAdd` fails there with `-34018` (`errSecMissingEntitlement`), see [issue_10](https://github.com/EddyVerbruggen/nativescript-secure-storage/issues/10). Enable it by passing `disableFallbackToUserDefaults: false` as the second constructor argument:
+
+```ts
+const secureStorage = new SecureStorage(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, false);
+```
+
+Note that the fallback stores values **unencrypted**, under the raw key, in the same `NSUserDefaults` domain that `ApplicationSettings` writes to, so those keys can collide with plain application settings. Only turn it on if the simulator keychain is genuinely unavailable to you.
 
 ## iOS Keychain Access/App Groups
 
@@ -152,7 +158,7 @@ To setup:
   ```
 
 ## Credits
-* On __iOS__ we're leveraging the KeyChain using the [SAMKeychain](https://github.com/soffes/SAMKeychain) library (on the Simulator `NSUserDefaults`),
+* On __iOS__ we're leveraging the KeyChain using the [SAMKeychain](https://github.com/soffes/SAMKeychain) library,
 * On __Android__ we're using [Hawk](https://github.com/orhanobut/hawk) library which internally uses [Facebook conceal](https://github.com/facebook/conceal).
 * Thanks, [Prabu Devarrajan](https://github.com/prabudevarrajan) for [adding the `deleteAll` function](https://github.com/EddyVerbruggen/nativescript-secure-storage/pull/11)!
 * Thank you [Eddy Verbruggen](https://github.com/EddyVerbruggen) for all the years of service and great work!

--- a/packages/secure-storage/index.ios.ts
+++ b/packages/secure-storage/index.ios.ts
@@ -11,23 +11,15 @@ export class SecureStorage extends SecureStorageCommon {
 	// This is a copy of 'kSSKeychainAccountKey_copy' which is not exposed from SSKeychain.h by {N}
 	private static kSSKeychainAccountKey_copy: string = 'acct';
 
-	constructor(accessibilityType: string = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, disableFallbackToUserDefaults = false) {
+	constructor(accessibilityType: string = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, disableFallbackToUserDefaults = true) {
 		super();
 
 		if (disableFallbackToUserDefaults) {
 			this.isSimulator = false;
 		} else {
-			const isMinIOS9 = NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({
-				majorVersion: 9,
-				minorVersion: 0,
-				patchVersion: 0,
-			});
-			if (isMinIOS9) {
-				const simDeviceName = NSProcessInfo.processInfo.environment.objectForKey('SIMULATOR_DEVICE_NAME');
-				this.isSimulator = simDeviceName !== null;
-			} else {
-				this.isSimulator = UIDevice.currentDevice.name.toLowerCase().indexOf('simulator') > -1;
-			}
+			// Only the simulator runtime sets this; anything derived from the device name can be spoofed by renaming a real device.
+			const simDeviceName = NSProcessInfo.processInfo.environment.objectForKey('SIMULATOR_DEVICE_NAME');
+			this.isSimulator = simDeviceName !== null;
 		}
 
 		this.accessibilityType = accessibilityType;


### PR DESCRIPTION
## Spoofable simulator detection downgrades secure storage to plaintext

`SecureStorage` on iOS decides whether to use the keychain or fall back to `NSUserDefaults` in its constructor. The pre-iOS-9 branch of that decision was:

```ts
this.isSimulator = UIDevice.currentDevice.name.toLowerCase().indexOf('simulator') > -1;
```

`UIDevice.name` is the user-editable device name (Settings → General → About → Name). A real device named e.g. "my simulator" therefore takes the fallback path, and **every** `get`/`set`/`remove` (sync and async) silently reads and writes plaintext `NSUserDefaults` instead of the keychain — with no error, no log, and no API difference. That is user-controlled input deciding whether secrets are encrypted.

The iOS 9 gate guarding that branch is dead code — the plugin's deployment target is far above iOS 9 — so the branch is removed entirely. Simulator detection is now solely the `SIMULATOR_DEVICE_NAME` environment variable, which is set by the simulator runtime and is not settable on a device.

## The fallback shares a namespace with plain application settings

When active, the fallback writes the raw, unprefixed key straight into `NSUserDefaults.standardUserDefaults` — the same domain and key namespace that `ApplicationSettings` and any other plain `NSUserDefaults` usage writes to. "Secure" and plain values collide on one store, so an app migrating a plaintext value into secure storage under the same key can destroy the value it is migrating, on the simulator only, in a way that never reproduces on device.

## Why flipping the default is safe

The fallback exists for the Xcode 8 / iOS 10 simulator era (2016), when `SecItemAdd` returned `-34018` (`errSecMissingEntitlement`) in simulator builds that had no embedded application-identifier entitlement (see [EddyVerbruggen/nativescript-secure-storage#10](https://github.com/EddyVerbruggen/nativescript-secure-storage/issues/10)). Since Xcode ~9 (2017) Xcode embeds entitlements into every simulator build via the `__TEXT,__entitlements` section, so the simulator keychain works the same as on device. The workaround has outlived its cause, and defaulting to it means the least secure path is the one nobody opts into.

`disableFallbackToUserDefaults` now defaults to `true`. The fallback remains available, unchanged, for anyone on a toolchain old enough to need it.

## Changes

- `packages/secure-storage/index.ios.ts`: `disableFallbackToUserDefaults` defaults to `true`; the iOS 9 version gate and the `UIDevice.currentDevice.name` detection branch are deleted, leaving the `SIMULATOR_DEVICE_NAME` check.
- `packages/secure-storage/README.md`: documents the new default, how to opt back in, and why the fallback is not equivalent to the keychain.

Android is untouched — the fallback is iOS-only.

## Breaking change

Values written on the iOS simulator through the old `NSUserDefaults` fallback are not visible to the keychain path and will read back as `null`. This affects simulator development data only; nothing on device changes, since device builds already used the keychain (unless the device name happened to contain "simulator", which is precisely the bug).

To restore the previous behaviour:

```ts
const secureStorage = new SecureStorage(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, false);
```

## Validation

`npx tsc -p packages/secure-storage/tsconfig.json --noEmit` passes; the touched TS file is prettier-clean. (The README was already not prettier-clean on `main`, so it was left unformatted rather than reformatted wholesale.)